### PR TITLE
fix: rosetta construction derive api

### DIFF
--- a/docs/api/rosetta/rosetta-construction-derive-response.schema.json
+++ b/docs/api/rosetta/rosetta-construction-derive-response.schema.json
@@ -4,11 +4,14 @@
   "type": "object",
   "title": "RosettaConstructionDeriveResponse",
   "description": "ConstructionDeriveResponse is returned by the /construction/derive endpoint.",
-  "required": ["address"],
+  "required": [],
   "properties": {
     "address": {
       "type": "string",
-      "description": "Address in network-specific format."
+      "description": "[DEPRECATED by account_identifier in v1.4.4] Address in network-specific format."
+    },
+    "account_identifier": {
+      "$ref": "./../../entities/rosetta/rosetta-account-identifier.schema.json"
     },
     "metadata": {
       "type": "object"

--- a/docs/index.d.ts
+++ b/docs/index.d.ts
@@ -453,9 +453,10 @@ export interface RosettaConstructionDeriveRequest {
  */
 export interface RosettaConstructionDeriveResponse {
   /**
-   * Address in network-specific format.
+   * [DEPRECATED by account_identifier in v1.4.4] Address in network-specific format.
    */
-  address: string;
+  address?: string;
+  account_identifier?: RosettaAccountIdentifier;
   metadata?: {
     [k: string]: unknown | undefined;
   };

--- a/package-lock.json
+++ b/package-lock.json
@@ -16614,39 +16614,11 @@
       "integrity": "sha512-zg7Hz2k5lI8kb7U32998pRRFin7zJlkfezGJjUc2heaD4Pw2wObakCDVzkKztTm/Ln7eiVvYsjqak0Ed4LkMDA=="
     },
     "axios": {
-      "version": "0.18.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.1.tgz",
-      "integrity": "sha512-0BfJq4NSfQXd+SkFdrvFbG7addhYSBA2mQwISr46pD6E5iqkWg02RAs8vyTT/j0RTnoYmeXauBuSv1qKwR179g==",
-      "dev": true,
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
       "requires": {
-        "follow-redirects": "1.5.10",
-        "is-buffer": "^2.0.2"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "follow-redirects": {
-          "version": "1.5.10",
-          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
-          "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
-          "dev": true,
-          "requires": {
-            "debug": "=3.1.0"
-          }
-        },
-        "is-buffer": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
-          "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==",
-          "dev": true
-        }
+        "follow-redirects": "^1.10.0"
       }
     },
     "babel-jest": {
@@ -25583,12 +25555,11 @@
       "integrity": "sha512-HAKu/fG3HpHFO0AA8WE8q2g+gBJaZ9MG7fcKk+IJPLTGAD6Psw4443l+9DGRbOIh3/aXr7Phy0TjilYivJo5XQ=="
     },
     "paged-request": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/paged-request/-/paged-request-2.0.1.tgz",
-      "integrity": "sha512-C0bB/PFk9rQskD1YEiz7uuchzqKDQGgdsEHN1ahify0UUWzgmMK4NDG9fhlQg2waogmNFwEvEeHfMRvJySpdVw==",
-      "dev": true,
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/paged-request/-/paged-request-2.0.2.tgz",
+      "integrity": "sha512-NWrGqneZImDdcMU/7vMcAOo1bIi5h/pmpJqe7/jdsy85BA/s5MSaU/KlpxwW/IVPmIwBcq2uKPrBWWhEWhtxag==",
       "requires": {
-        "axios": "^0.18.0"
+        "axios": "^0.21.1"
       }
     },
     "pako": {

--- a/src/api/routes/rosetta/construction.ts
+++ b/src/api/routes/rosetta/construction.ts
@@ -2,6 +2,7 @@ import { addAsync, RouterWithAsync } from '@awaitjs/express';
 import * as BN from 'bn.js';
 import {
   NetworkIdentifier,
+  RosettaAccountIdentifier,
   RosettaConstructionDeriveResponse,
   RosettaConstructionHashRequest,
   RosettaConstructionHashResponse,
@@ -93,8 +94,11 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
       }
       const stxAddress = bitcoinAddressToSTXAddress(btcAddress);
 
+      const accountIdentifier: RosettaAccountIdentifier = {
+        address: stxAddress, 
+      };
       const response: RosettaConstructionDeriveResponse = {
-        address: stxAddress,
+        account_identifier: accountIdentifier,
       };
       res.json(response);
     } catch (e) {

--- a/src/tests-rosetta/api.ts
+++ b/src/tests-rosetta/api.ts
@@ -32,6 +32,7 @@ import {
   RosettaAccount,
   RosettaAccountBalanceRequest,
   RosettaAccountBalanceResponse,
+  RosettaAccountIdentifier,
   RosettaAmount,
   RosettaConstructionDeriveRequest,
   RosettaConstructionDeriveResponse,
@@ -753,8 +754,11 @@ describe('Rosetta API', () => {
     expect(result.status).toBe(200);
     expect(result.type).toBe('application/json');
 
+    const accountIdentifier: RosettaAccountIdentifier = {
+      address: 'ST19SH1QSCR8VMEX6SVWP33WCF08RPDY5QVHX94BM', 
+    };
     const expectResponse: RosettaConstructionDeriveResponse = {
-      address: 'ST19SH1QSCR8VMEX6SVWP33WCF08RPDY5QVHX94BM',
+      account_identifier: accountIdentifier,
     };
 
     expect(JSON.parse(result.text)).toEqual(expectResponse);


### PR DESCRIPTION
## Description

Update the rosetta `construction/derive` api to use `account_identifier` and not the deprecated `address`. See rosetta spec (https://www.rosetta-api.org/docs/models/ConstructionDeriveResponse.html)

It also update npm package axios because of a `Server-Side Request Forgery` vulnerability in the current version of the package.
 
For details refer to issue #10 

The modifications include:
- [x] update npm package axios
- [x] updating the schema file for the rosetta construction derive file
- [x] generating new typescript files
- [x] updating the api implementation to return the proper response
- [x] updating the test for this specific endpoint