### PR TITLE
fix: change rosetta construction parse api

### DIFF
--- a/docs/api/rosetta/rosetta-construction-parse-response.schema.json
+++ b/docs/api/rosetta/rosetta-construction-parse-response.schema.json
@@ -4,7 +4,7 @@
   "type": "object",
   "title": "RosettaConstructionParseResponse",
   "description": "RosettaConstructionParseResponse contains an array of operations that occur in a transaction blob. This should match the array of operations provided to /construction/preprocess and /construction/payloads.",
-  "required": ["operations", "metadata"],
+  "required": ["operations"],
   "properties": {
     "operations": {
       "type": "array",
@@ -28,6 +28,9 @@
       "items": {
         "$ref": "./../../entities/rosetta/rosetta-account-identifier.schema.json"
       }
+    },
+    "metadata": {
+      "type": "object"
     }
   }
 }

--- a/docs/index.d.ts
+++ b/docs/index.d.ts
@@ -538,6 +538,9 @@ export interface RosettaConstructionParseResponse {
    */
   signers?: string[];
   account_identifier_signers?: RosettaAccountIdentifier[];
+  metadata?: {
+    [k: string]: unknown | undefined;
+  };
 }
 
 /**


### PR DESCRIPTION
## Description

metadata in response not required on the /construction/parse endpoint.

Closes #11 

The modifications only include the schema file and the newly generated TypeScript types.