### PR TITLE
fix: combine endpoint to revert RSV to VRS

### DIFF
--- a/src/api/rosetta-constants.ts
+++ b/src/api/rosetta-constants.ts
@@ -245,6 +245,11 @@ export const RosettaErrors: Record<string, RosettaError> = {
     message: 'Need only one signature',
     retriable: false,
   },
+  signatureTypeNotSupported: {
+    code: 638,
+    message: 'Signature type not supported.',
+    retriable: false,
+  },
 };
 
 // All request types, used to validate input.

--- a/src/tests-rosetta/api.ts
+++ b/src/tests-rosetta/api.ts
@@ -151,6 +151,7 @@ describe('Rosetta API', () => {
           },
           { code: 636, message: 'Need one public key for single signature', retriable: false },
           { code: 637, message: 'Need only one signature', retriable: false },
+          { code: 638, message: 'Signature type not supported.', retriable: false },
         ],
         historical_balance_lookup: true,
       },
@@ -1940,13 +1941,13 @@ describe('Rosetta API', () => {
           signing_payload: {
             hex_bytes:
               '017c7fc676effda9d905440a052d304b5d9705c30625e654f5b3c9ed461337cdec695d14e5f24091d61f8409f2ab703102ca840dbf5ef752ec534fe1f418552201',
-            signature_type: 'ecdsa',
+            signature_type: 'ecdsa_recovery',
           },
           public_key: {
             hex_bytes: '025c13b2fc2261956d8a4ad07d481b1a3b2cbf93a24f992249a61c3a1c4de79c51',
             curve_type: 'secp256k1',
           },
-          signature_type: 'ecdsa',
+          signature_type: 'ecdsa_recovery',
           hex_bytes:
             '017c7fc676effda9d905440a052d304b5d9705c30625e654f5b3c9ed461337cdec695d14e5f24091d61f8409f2ab703102ca840dbf5ef752ec534fe1f418552201',
         },
@@ -1977,13 +1978,13 @@ describe('Rosetta API', () => {
           signing_payload: {
             hex_bytes:
               '36212600bf7463399a23c398f29ca7006b9986b4a01129dd7c6e89314607208e516b0b28c1d850fe6e164abea7b6cceb4aa09700a6d218d1b605d4a402d3038f01',
-            signature_type: 'ecdsa',
+            signature_type: 'ecdsa_recovery',
           },
           public_key: {
             hex_bytes: '025c13b2fc2261956d8a4ad07d481b1a3b2cbf93a24f992249a61c3a1c4de79c51',
             curve_type: 'secp256k1',
           },
-          signature_type: 'ecdsa',
+          signature_type: 'ecdsa_recovery',
           hex_bytes:
             '36212600bf7463399a23c398f29ca7006b9986b4a01129dd7c6e89314607208e516b0b28c1d850fe6e164abea7b6cceb4aa09700a6d218d1b605d4a402d3038f01',
         },
@@ -2014,7 +2015,7 @@ describe('Rosetta API', () => {
         {
           signing_payload: {
             hex_bytes: 'invalid signature',
-            signature_type: 'ecdsa',
+            signature_type: 'ecdsa_recovery',
           },
           public_key: {
             hex_bytes: '025c13b2fc2261956d8a4ad07d481b1a3b2cbf93a24f992249a61c3a1c4de79c51',
@@ -2070,13 +2071,13 @@ describe('Rosetta API', () => {
         {
           signing_payload: {
             hex_bytes: signature.data,
-            signature_type: 'ecdsa',
+            signature_type: 'ecdsa_recovery',
           },
           public_key: {
             hex_bytes: '025c13b2fc2261956d8a4ad07d481b1a3b2cbf93a24f992249a61c3a1c4de79c51',
             curve_type: 'secp256k1',
           },
-          signature_type: 'ecdsa',
+          signature_type: 'ecdsa_recovery',
           hex_bytes: signature.data,
         },
       ],
@@ -2107,13 +2108,13 @@ describe('Rosetta API', () => {
           signing_payload: {
             hex_bytes:
               '36212600bf7463399a23c398f29ca7006b9986b4a01129dd7c6e89314607208e516b0b28c1d850fe6e164abea7b6cceb4aa09700a6d218d1b605d4a402d3038f01',
-            signature_type: 'ecdsa',
+            signature_type: 'ecdsa_recovery',
           },
           public_key: {
             hex_bytes: 'invalid  public key',
             curve_type: 'secp256k1',
           },
-          signature_type: 'ecdsa',
+          signature_type: 'ecdsa_recovery',
           hex_bytes:
             '36212600bf7463399a23c398f29ca7006b9986b4a01129dd7c6e89314607208e516b0b28c1d850fe6e164abea7b6cceb4aa09700a6d218d1b605d4a402d3038f01',
         },

--- a/src/tests-rosetta/api.ts
+++ b/src/tests-rosetta/api.ts
@@ -1871,7 +1871,7 @@ describe('Rosetta API', () => {
     signer.signOrigin(createStacksPrivateKey(testnetKeys[0].secretKey));
     const signedSerializedTx = signer.transaction.serialize().toString('hex');
 
-    const signature: MessageSignature = getSignature(signer.transaction) as MessageSignature;
+    let signature = getSignature(signer.transaction) as MessageSignature;
 
     const request: RosettaConstructionCombineRequest = {
       network_identifier: {
@@ -1976,7 +1976,7 @@ describe('Rosetta API', () => {
         {
           signing_payload: {
             hex_bytes:
-              '0136212600bf7463399a23c398f29ca7006b9986b4a01129dd7c6e89314607208e516b0b28c1d850fe6e164abea7b6cceb4aa09700a6d218d1b605d4a402d3038f',
+              '36212600bf7463399a23c398f29ca7006b9986b4a01129dd7c6e89314607208e516b0b28c1d850fe6e164abea7b6cceb4aa09700a6d218d1b605d4a402d3038f01',
             signature_type: 'ecdsa',
           },
           public_key: {
@@ -1985,7 +1985,7 @@ describe('Rosetta API', () => {
           },
           signature_type: 'ecdsa',
           hex_bytes:
-            '0136212600bf7463399a23c398f29ca7006b9986b4a01129dd7c6e89314607208e516b0b28c1d850fe6e164abea7b6cceb4aa09700a6d218d1b605d4a402d3038f',
+            '36212600bf7463399a23c398f29ca7006b9986b4a01129dd7c6e89314607208e516b0b28c1d850fe6e164abea7b6cceb4aa09700a6d218d1b605d4a402d3038f01',
         },
       ],
     };
@@ -2106,7 +2106,7 @@ describe('Rosetta API', () => {
         {
           signing_payload: {
             hex_bytes:
-              '0136212600bf7463399a23c398f29ca7006b9986b4a01129dd7c6e89314607208e516b0b28c1d850fe6e164abea7b6cceb4aa09700a6d218d1b605d4a402d3038f',
+              '36212600bf7463399a23c398f29ca7006b9986b4a01129dd7c6e89314607208e516b0b28c1d850fe6e164abea7b6cceb4aa09700a6d218d1b605d4a402d3038f01',
             signature_type: 'ecdsa',
           },
           public_key: {
@@ -2115,7 +2115,7 @@ describe('Rosetta API', () => {
           },
           signature_type: 'ecdsa',
           hex_bytes:
-            '0136212600bf7463399a23c398f29ca7006b9986b4a01129dd7c6e89314607208e516b0b28c1d850fe6e164abea7b6cceb4aa09700a6d218d1b605d4a402d3038f',
+            '36212600bf7463399a23c398f29ca7006b9986b4a01129dd7c6e89314607208e516b0b28c1d850fe6e164abea7b6cceb4aa09700a6d218d1b605d4a402d3038f01',
         },
       ],
     };

--- a/src/tests-rosetta/api.ts
+++ b/src/tests-rosetta/api.ts
@@ -1872,7 +1872,7 @@ describe('Rosetta API', () => {
     signer.signOrigin(createStacksPrivateKey(testnetKeys[0].secretKey));
     const signedSerializedTx = signer.transaction.serialize().toString('hex');
 
-    let signature = getSignature(signer.transaction) as MessageSignature;
+    const signature: MessageSignature = getSignature(signer.transaction) as MessageSignature;
 
     const request: RosettaConstructionCombineRequest = {
       network_identifier: {


### PR DESCRIPTION
The implementation was only formatting to VRS (blockstack signature format) only if it was starting with `01`. However the V value can be 4 differents value : `00`, `01`, `02` or `03`.

The test was failing randomly because of this.

This PR :
- [x] update the rosetta `combine` endpoint implementation to match the spec (https://www.rosetta-api.org/docs/models/SignatureType.html)
- [x] update the tests to create rosetta compliant signature 