### PR TITLE
fix: Added  suggested fee

### DIFF
--- a/docs/entities/rosetta/rosetta-construction-options.schema.json
+++ b/docs/entities/rosetta/rosetta-construction-options.schema.json
@@ -23,7 +23,7 @@
     },
     "amount": {
       "type": "string",
-      "description": "Amount to be transfeered."
+      "description": "Amount to be transfered."
     },
     "symbol": {
       "type": "string",
@@ -52,6 +52,10 @@
     "fee": {
       "type": "string",
       "description": "Fee for this transaction"
+    },
+    "size": {
+      "type": "number",
+      "description": "Transaction approximative size (used to calculate total fee)."
     }
   }
 }

--- a/docs/index.d.ts
+++ b/docs/index.d.ts
@@ -1254,7 +1254,19 @@ export interface NftEvent {
   sender: string;
   recipient: string;
   asset_identifier: string;
-  value: { hex: string; repr: string };
+  /**
+   * Identifier of the NFT
+   */
+  value: {
+    /**
+     * Hex string representing the identifier of the NFT
+     */
+    hex: string;
+    /**
+     * Readable string of the NFT identifier
+     */
+    repr: string;
+  };
   tx_id: string;
   block_height: number;
 }
@@ -1520,7 +1532,7 @@ export interface RosettaOptions {
    */
   token_transfer_recipient_address?: string;
   /**
-   * Amount to be transfeered.
+   * Amount to be transfered.
    */
   amount?: string;
   /**
@@ -1551,6 +1563,10 @@ export interface RosettaOptions {
    * Fee for this transaction
    */
   fee?: string;
+  /**
+   * Transaction approximative size (used to calculate total fee).
+   */
+  size?: number;
 }
 
 /**
@@ -1816,7 +1832,7 @@ export interface RosettaSignature {
  */
 export interface SigningPayload {
   /**
-   * The network-specific address of the account that should sign the payload.
+   * [DEPRECATED by account_identifier in v1.4.4] The network-specific address of the account that should sign the payload.
    */
   address?: string;
   account_identifier?: RosettaAccount;

--- a/src/api/rosetta-constants.ts
+++ b/src/api/rosetta-constants.ts
@@ -100,6 +100,7 @@ export enum RosettaErrorsTypes {
   needOnePublicKey,
   needOnlyOneSignature,
   signatureTypeNotSupported,
+  missingTransactionSize,
 }
 
 // All possible errors
@@ -299,6 +300,11 @@ export const RosettaErrors: Record<RosettaErrorsTypes, RosettaError> = {
   [RosettaErrorsTypes.signatureTypeNotSupported]: {
     code: 638,
     message: 'Signature type not supported.',
+    retriable: false,
+  },
+  [RosettaErrorsTypes.missingTransactionSize]: {
+    code: 638,
+    message: 'Transaction size required to calculate total fee.',
     retriable: false,
   },
 };

--- a/src/core-rpc/client.ts
+++ b/src/core-rpc/client.ts
@@ -1,5 +1,6 @@
 import fetch, { RequestInit } from 'node-fetch';
 import { parsePort, stopwatch, logError, timeout } from '../helpers';
+import { CoreNodeFeeResponse } from '@blockstack/stacks-blockchain-api-types';
 
 export interface CoreRpcAccountInfo {
   /** Hex-prefixed uint128. */
@@ -176,4 +177,11 @@ export class StacksCoreRpcClient {
     });
     return result;
   }
+
+  async getEstimatedTransferFee(): Promise<CoreNodeFeeResponse> {
+    const result = await this.fetchJson<CoreNodeFeeResponse>(`v2/fees/transfer`, {
+      method: 'GET',
+    });
+    return result;
+  } 
 }

--- a/src/core-rpc/client.ts
+++ b/src/core-rpc/client.ts
@@ -183,5 +183,5 @@ export class StacksCoreRpcClient {
       method: 'GET',
     });
     return result;
-  } 
+  }
 }

--- a/src/tests-rosetta/api.ts
+++ b/src/tests-rosetta/api.ts
@@ -859,6 +859,7 @@ describe('Rosetta API', () => {
         decimals: 6,
         fee: '-180',
         max_fee: '12380898',
+        size: 180,
       },
       required_public_keys: [
         {
@@ -984,6 +985,7 @@ describe('Rosetta API', () => {
         decimals: 6,
         fee: '-180',
         max_fee: '12380898',
+        size: 180,
       },
       public_keys: [{ hex_bytes: publicKey, curve_type: 'secp256k1' }],
     };
@@ -992,9 +994,13 @@ describe('Rosetta API', () => {
       .post(`/rosetta/v1/construction/metadata`)
       .send(request);
 
+    console.log(result.text);
+
     expect(result.status).toBe(200);
     expect(result.type).toBe('application/json');
     expect(JSON.parse(result.text)).toHaveProperty('metadata');
+    expect(JSON.parse(result.text)).toHaveProperty('suggested_fee');
+    expect(JSON.parse(result.text).suggested_fee.value).toBe('180');
   });
 
   test('construction/metadata - failure invalid public key', async () => {
@@ -1016,6 +1022,7 @@ describe('Rosetta API', () => {
         decimals: 6,
         fee: '-180',
         max_fee: '12380898',
+        size: 180,
       },
       public_keys: [
         {
@@ -1047,6 +1054,7 @@ describe('Rosetta API', () => {
         decimals: 6,
         fee: '-180',
         max_fee: '12380898',
+        size: 180,
       },
     };
 
@@ -1085,6 +1093,7 @@ describe('Rosetta API', () => {
         decimals: 6,
         fee: '-180',
         max_fee: '12380898',
+        size: 180,
       },
     };
 
@@ -1120,6 +1129,7 @@ describe('Rosetta API', () => {
         decimals: 6,
         fee: '-180',
         max_fee: '12380898',
+        size: 180,
       },
     };
 
@@ -1155,6 +1165,7 @@ describe('Rosetta API', () => {
         decimals: 6,
         fee: '-180',
         max_fee: '12380898',
+        size: 180,
       },
     };
 

--- a/src/tests/core-rpc-tests.ts
+++ b/src/tests/core-rpc-tests.ts
@@ -26,4 +26,9 @@ describe('core RPC tests', () => {
     const balance = await client.getAccountBalance('STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6');
     expect(balance).toBe(10000000000000000n);
   });
+
+  test('get estimated transfer fee', async () => {
+    const fee = await client.getEstimatedTransferFee();
+    expect(fee).toBeTruthy();
+  });
 });


### PR DESCRIPTION
Inform suggested fee using estimated fee endpoint and calculate tx size.

fee endpoint return an estimation per byte (see https://blockstack.github.io/stacks-blockchain-api/#operation/get_fee_transfer)