### PR TITLE
[BLOCKED] fix: simplify rosetta transaction build

### DIFF
--- a/docs/entities/rosetta/rosetta-construction-options.schema.json
+++ b/docs/entities/rosetta/rosetta-construction-options.schema.json
@@ -18,7 +18,7 @@
       "description": "This value indicates the state of the operations"
     },
     "token_transfer_recipient_address": {
-      "type": "string",
+      "type": ["string", "null"],
       "description": "Recipient's address"
     },
     "amount": {
@@ -32,14 +32,6 @@
     "decimals": {
       "type": "integer",
       "description": "Number of decimal places"
-    },
-    "gas_limit": {
-      "type": "number",
-      "description": "Maximum price a user is willing to pay."
-    },
-    "gas_price": {
-      "type": "number",
-      "description": "Cost necessary to perform a transaction on the network"
     },
     "suggested_fee_multiplier": {
       "type": "number",

--- a/docs/entities/rosetta/rosetta-operation.schema.json
+++ b/docs/entities/rosetta/rosetta-operation.schema.json
@@ -34,18 +34,7 @@
     },
     "metadata": {
       "type": "object",
-      "description": "Operations Meta Data",
-      "required": ["asm", "hex"],
-      "properties": {
-        "asm": {
-          "type": "string",
-          "description": "The asm"
-        },
-        "hex": {
-          "type": "string",
-          "description": "The hex"
-        }
-      }
+      "description": "Operations metadata",
     }
   }
 }

--- a/docs/index.d.ts
+++ b/docs/index.d.ts
@@ -1530,7 +1530,7 @@ export interface RosettaOptions {
   /**
    * Recipient's address
    */
-  token_transfer_recipient_address?: string;
+  token_transfer_recipient_address?: string | null;
   /**
    * Amount to be transfered.
    */
@@ -1543,14 +1543,6 @@ export interface RosettaOptions {
    * Number of decimal places
    */
   decimals?: number;
-  /**
-   * Maximum price a user is willing to pay.
-   */
-  gas_limit?: number;
-  /**
-   * Cost necessary to perform a transaction on the network
-   */
-  gas_price?: number;
   /**
    *  A suggested fee multiplier to indicate that the suggested fee should be scaled. This may be used to set higher fees for urgent transactions or to pay lower fees when there is less urgency.
    */
@@ -1742,17 +1734,9 @@ export interface RosettaOperation {
   amount?: RosettaAmount;
   coin_change?: RosettaCoinChange;
   /**
-   * Operations Meta Data
+   * Operations metadata
    */
   metadata?: {
-    /**
-     * The asm
-     */
-    asm: string;
-    /**
-     * The hex
-     */
-    hex: string;
     [k: string]: unknown | undefined;
   };
 }

--- a/src/api/routes/rosetta/construction.ts
+++ b/src/api/routes/rosetta/construction.ts
@@ -51,7 +51,7 @@ import { RosettaConstants, RosettaErrors, RosettaErrorsTypes } from '../../roset
 import {
   bitcoinAddressToSTXAddress,
   getOperations,
-  getOptionsFromOperations,
+  getOptionsFromOperation,
   getSigners,
   isDecimalsSupported,
   isSignedTransaction,
@@ -118,8 +118,8 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
 
     const operations: RosettaOperation[] = req.body.operations;
 
-    // We are only supporting transfer, we should have operations length = 2
-    if (operations.length != 2) {
+    // We are only supporting transfer, we should have operations length = 1
+    if (operations.length != 1) {
       res.status(400).json(RosettaErrors[RosettaErrorsTypes.invalidOperation]);
       return;
     }
@@ -134,24 +134,14 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
       return;
     }
 
-    const options = getOptionsFromOperations(req.body.operations);
+    const options = getOptionsFromOperation(operations[0]);
     if (options == null) {
       res.status(400).json(RosettaErrors[RosettaErrorsTypes.invalidOperation]);
       return;
     }
 
-    if (req.body.metadata) {
-      if (req.body.metadata.gas_limit) {
-        options.gas_limit = req.body.metadata.gas_limit;
-      }
-
-      if (req.body.metadata.gas_price) {
-        options.gas_price = req.body.metadata.gas_price;
-      }
-
-      if (req.body.suggested_fee_multiplier) {
-        options.suggested_fee_multiplier = req.body.suggested_fee_multiplier;
-      }
+    if (req.body.suggested_fee_multiplier) {
+      options.suggested_fee_multiplier = req.body.suggested_fee_multiplier;
     }
 
     if (req.body.max_fee) {
@@ -437,7 +427,7 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
       return;
     }
 
-    const options = getOptionsFromOperations(req.body.operations);
+    const options = getOptionsFromOperation(req.body.operations[0]);
     if (options == null) {
       res.status(400).json(RosettaErrors[RosettaErrorsTypes.invalidOperation]);
       return;

--- a/src/rosetta-helpers.ts
+++ b/src/rosetta-helpers.ts
@@ -228,8 +228,7 @@ export function bitcoinAddressToSTXAddress(btcAddress: string): string {
 export function getOptionsFromOperation(operation: RosettaOperation): RosettaOptions | null {
   switch (operation.type) {
     case 'token_transfer':
-
-      const recipient_address = operation.metadata?.recipient_address as string || null;
+      const recipient_address = (operation.metadata?.recipient_address as string) || null;
       if (recipient_address === null) {
         return null;
       }

--- a/src/tests-rosetta/api.ts
+++ b/src/tests-rosetta/api.ts
@@ -861,7 +861,7 @@ describe('Rosetta API', () => {
             metadata: {},
           },
           metadata: {
-            recipient_address: "STDE7Y8HV3RX8VBM2TZVWJTS7ZA1XB0SSC3NEVH0",
+            recipient_address: 'STDE7Y8HV3RX8VBM2TZVWJTS7ZA1XB0SSC3NEVH0',
           },
         },
       ],
@@ -1455,7 +1455,7 @@ describe('Rosetta API', () => {
           },
           metadata: {
             recipient_address: recipient,
-          }
+          },
         },
       ],
       metadata: {
@@ -1514,7 +1514,7 @@ describe('Rosetta API', () => {
           },
           metadata: {
             recipient_address: 'STDE7Y8HV3RX8VBM2TZVWJTS7ZA1XB0SSC3NEVH0',
-          }
+          },
         },
       ],
       metadata: {
@@ -1563,7 +1563,7 @@ describe('Rosetta API', () => {
           },
           metadata: {
             recipient_address: 'STDE7Y8HV3RX8VBM2TZVWJTS7ZA1XB0SSC3NEVH0',
-          }
+          },
         },
       ],
       metadata: {

--- a/src/tests-rosetta/api.ts
+++ b/src/tests-rosetta/api.ts
@@ -60,7 +60,7 @@ import {
   RosettaOperationStatuses,
 } from '../api/rosetta-constants';
 import { getStacksTestnetNetwork, testnetKeys } from '../api/routes/debug';
-import { getOptionsFromOperations, getSignature } from '../rosetta-helpers';
+import { getSignature } from '../rosetta-helpers';
 import { makeSigHashPreSign, MessageSignature } from '@stacks/transactions';
 
 describe('Rosetta API', () => {
@@ -776,27 +776,6 @@ describe('Rosetta API', () => {
             metadata: {},
           },
           amount: {
-            value: '-500000',
-            currency: {
-              symbol: 'STX',
-              decimals: 6,
-            },
-            metadata: {},
-          },
-        },
-        {
-          operation_identifier: {
-            index: 1,
-            network_index: 0,
-          },
-          related_operations: [],
-          type: 'token_transfer',
-          status: null,
-          account: {
-            address: 'STDE7Y8HV3RX8VBM2TZVWJTS7ZA1XB0SSC3NEVH0',
-            metadata: {},
-          },
-          amount: {
             value: '500000',
             currency: {
               symbol: 'STX',
@@ -804,9 +783,11 @@ describe('Rosetta API', () => {
             },
             metadata: {},
           },
+          metadata: {
+            recipient_address: 'STDE7Y8HV3RX8VBM2TZVWJTS7ZA1XB0SSC3NEVH0',
+          },
         },
       ],
-      metadata: {},
       max_fee: [
         {
           value: '12380898',
@@ -823,6 +804,8 @@ describe('Rosetta API', () => {
     const result = await supertest(api.server)
       .post(`/rosetta/v1/construction/preprocess`)
       .send(request);
+
+    console.log(result);
 
     expect(result.status).toBe(200);
     expect(result.type).toBe('application/json');
@@ -877,30 +860,11 @@ describe('Rosetta API', () => {
             },
             metadata: {},
           },
-        },
-        {
-          operation_identifier: {
-            index: 1,
-            network_index: 0,
-          },
-          related_operations: [],
-          type: 'token_transfer',
-          status: null,
-          account: {
-            address: 'STDE7Y8HV3RX8VBM2TZVWJTS7ZA1XB0SSC3NEVH0',
-            metadata: {},
-          },
-          amount: {
-            value: '500000',
-            currency: {
-              symbol: 'STX',
-              decimals: 6,
-            },
-            metadata: {},
+          metadata: {
+            recipient_address: "STDE7Y8HV3RX8VBM2TZVWJTS7ZA1XB0SSC3NEVH0",
           },
         },
       ],
-      metadata: {},
       max_fee: [
         {
           value: '12380898',
@@ -1082,7 +1046,6 @@ describe('Rosetta API', () => {
         amount: '500000',
         symbol: 'STX',
         decimals: 6,
-        fee: '-180',
         max_fee: '12380898',
         size: 180,
       },
@@ -1390,33 +1353,15 @@ describe('Rosetta API', () => {
             metadata: {},
           },
           amount: {
-            value: '-500000',
-            currency: {
-              symbol: 'STX',
-              decimals: 6,
-            },
-            metadata: {},
-          },
-        },
-        {
-          operation_identifier: {
-            index: 1,
-            network_index: 0,
-          },
-          related_operations: [],
-          type: 'token_transfer',
-          status: null,
-          account: {
-            address: recipient,
-            metadata: {},
-          },
-          amount: {
             value: '500000',
             currency: {
               symbol: 'STX',
               decimals: 6,
             },
             metadata: {},
+          },
+          metadata: {
+            recipient_address: recipient,
           },
         },
       ],
@@ -1501,27 +1446,6 @@ describe('Rosetta API', () => {
             metadata: {},
           },
           amount: {
-            value: '-500000',
-            currency: {
-              symbol: 'STX',
-              decimals: 6,
-            },
-            metadata: {},
-          },
-        },
-        {
-          operation_identifier: {
-            index: 1,
-            network_index: 0,
-          },
-          related_operations: [],
-          type: 'token_transfer',
-          status: null,
-          account: {
-            address: recipient,
-            metadata: {},
-          },
-          amount: {
             value: '500000',
             currency: {
               symbol: 'STX',
@@ -1529,6 +1453,9 @@ describe('Rosetta API', () => {
             },
             metadata: {},
           },
+          metadata: {
+            recipient_address: recipient,
+          }
         },
       ],
       metadata: {
@@ -1585,27 +1512,9 @@ describe('Rosetta API', () => {
             },
             metadata: {},
           },
-        },
-        {
-          operation_identifier: {
-            index: 1,
-            network_index: 0,
-          },
-          related_operations: [],
-          type: 'token_transfer',
-          status: null,
-          account: {
-            address: 'STDE7Y8HV3RX8VBM2TZVWJTS7ZA1XB0SSC3NEVH0',
-            metadata: {},
-          },
-          amount: {
-            value: '500000',
-            currency: {
-              symbol: 'STX',
-              decimals: 6,
-            },
-            metadata: {},
-          },
+          metadata: {
+            recipient_address: 'STDE7Y8HV3RX8VBM2TZVWJTS7ZA1XB0SSC3NEVH0',
+          }
         },
       ],
       metadata: {
@@ -1652,27 +1561,9 @@ describe('Rosetta API', () => {
             },
             metadata: {},
           },
-        },
-        {
-          operation_identifier: {
-            index: 1,
-            network_index: 0,
-          },
-          related_operations: [],
-          type: 'token_transfer',
-          status: null,
-          account: {
-            address: 'STDE7Y8HV3RX8VBM2TZVWJTS7ZA1XB0SSC3NEVH0',
-            metadata: {},
-          },
-          amount: {
-            value: '500000',
-            currency: {
-              symbol: 'STX',
-              decimals: 6,
-            },
-            metadata: {},
-          },
+          metadata: {
+            recipient_address: 'STDE7Y8HV3RX8VBM2TZVWJTS7ZA1XB0SSC3NEVH0',
+          }
         },
       ],
       metadata: {


### PR DESCRIPTION
Simplify how we build a transaction by taking advantage of the `metadata` field.

One transaction is now one operation.

!!! Waiting for more information !!!