### PR TITLE
Stacks-events parser

### DIFF
--- a/src/api/controllers/db-controller.ts
+++ b/src/api/controllers/db-controller.ts
@@ -282,7 +282,7 @@ export async function getRosettaBlockFromDataStore(
     return { found: false };
   }
   const dbBlock = blockQuery.result;
-  let blockTxs = <FoundOrNot<RosettaTransaction[]>>{};
+  let blockTxs = {} as FoundOrNot<RosettaTransaction[]>;
   blockTxs.found = false;
   if (fetchTransactions) {
     blockTxs = await getRosettaBlockTransactionsFromDataStore(

--- a/src/api/rosetta-constants.ts
+++ b/src/api/rosetta-constants.ts
@@ -41,6 +41,7 @@ export const RosettaOperationTypes = [
   'poison_microblock',
   'fee',
   'mint',
+  'miner_reward',
 ];
 
 export const RosettaOperationStatuses = [

--- a/src/api/rosetta-constants.ts
+++ b/src/api/rosetta-constants.ts
@@ -40,6 +40,7 @@ export const RosettaOperationTypes = [
   'coinbase',
   'poison_microblock',
   'fee',
+  'mint',
 ];
 
 export const RosettaOperationStatuses = [

--- a/src/api/rosetta-constants.ts
+++ b/src/api/rosetta-constants.ts
@@ -45,6 +45,7 @@ export const RosettaOperationTypes = [
   'poison_microblock',
   'fee',
   'mint',
+  'burn',
   'miner_reward',
 ];
 

--- a/src/api/rosetta-constants.ts
+++ b/src/api/rosetta-constants.ts
@@ -21,6 +21,10 @@ export const ReferenceNodes: { [key: string]: any } = {
     host: 'seed-2.mainnet.stacks.co',
     port: '20443',
   },
+  testnet: {
+    host: 'testnet.stacks.co',
+    port: '20443',
+  },
 };
 
 export function getRosettaNetworkName(chainId: ChainID): string {

--- a/src/api/rosetta-constants.ts
+++ b/src/api/rosetta-constants.ts
@@ -304,7 +304,7 @@ export const RosettaErrors: Record<RosettaErrorsTypes, RosettaError> = {
     retriable: false,
   },
   [RosettaErrorsTypes.missingTransactionSize]: {
-    code: 638,
+    code: 639,
     message: 'Transaction size required to calculate total fee.',
     retriable: false,
   },
@@ -315,7 +315,6 @@ export type RosettaRequestType =
   | T.RosettaAccountBalanceRequest
   | T.RosettaBlockRequest
   | T.RosettaBlockTransactionRequest
-  | T.RosettaMempoolTransactionRequest
   | T.RosettaMempoolTransactionRequest
   | T.RosettaNetworkListRequest
   | T.RosettaOptionsRequest

--- a/src/api/routes/rosetta/account.ts
+++ b/src/api/routes/rosetta/account.ts
@@ -68,6 +68,7 @@ export function createRosettaAccountRouter(db: DataStore, chainId: ChainID): Rou
 
     if (subAccountIdentifier !== undefined) {
       switch (subAccountIdentifier.address) {
+        // Refers to staked tokens
         case RosettaConstants.lockedBalance:
           const lockedBalance = stxBalance.locked;
           balance = lockedBalance.toString();

--- a/src/api/routes/rosetta/block.ts
+++ b/src/api/routes/rosetta/block.ts
@@ -28,7 +28,7 @@ export function createRosettaBlockRouter(db: DataStore, chainId: ChainID): Route
       block_hash = '0x' + block_hash;
     }
 
-    const block = await getRosettaBlockFromDataStore(db, block_hash, index);
+    const block = await getRosettaBlockFromDataStore(db, true, block_hash, index);
 
     if (!block.found) {
       res.status(404).json(RosettaErrors[RosettaErrorsTypes.blockNotFound]);

--- a/src/api/routes/rosetta/construction.ts
+++ b/src/api/routes/rosetta/construction.ts
@@ -210,12 +210,7 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
           contractName: 'pox',
           functionName: 'stack-stx',
           publicKey: '000000000000000000000000000000000000000000000000000000000000000000',
-          functionArgs: [
-            uintCV(options.amount),
-            poxAddressCV,
-            uintCV(0),
-            uintCV(0),
-          ],
+          functionArgs: [uintCV(options.amount), poxAddressCV, uintCV(0), uintCV(0)],
           validateWithAbi: true,
           network: getStacksNetwork(),
         };
@@ -275,7 +270,7 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
           res.status(400).json(RosettaErrors[RosettaErrorsTypes.invalidCurrencyDecimals]);
           return;
         }
-    
+
         if (recipientAddress == null || !isValidC32Address(recipientAddress)) {
           res.status(400).json(RosettaErrors[RosettaErrorsTypes.invalidRecipient]);
           return;
@@ -285,7 +280,7 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
         // Getting stacking info
         const poxInfo = await new StacksCoreRpcClient().getPox();
         const coreInfo = await new StacksCoreRpcClient().getInfo();
-        const contractInfo = poxInfo.contract_id.split('.')
+        const contractInfo = poxInfo.contract_id.split('.');
         options.contract_address = contractInfo[0];
         options.contract_name = contractInfo[1];
         // Adding 3 blocks to provide a buffer for transaction to confirm
@@ -300,7 +295,7 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
       res.status(400).json(RosettaErrors[RosettaErrorsTypes.invalidPublicKey]);
       return;
     }
-    
+
     const publicKey: RosettaPublicKey = request.public_keys[0];
 
     if (has0xPrefix(publicKey.hex_bytes)) {
@@ -327,7 +322,6 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
       res.status(400).json(RosettaErrors[RosettaErrorsTypes.invalidPublicKey]);
       return;
     }
-
 
     // Getting nonce info
     const accountInfo = await new StacksCoreRpcClient().getAccount(stxAddress);
@@ -551,7 +545,7 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
       res.status(400).json(RosettaErrors[RosettaErrorsTypes.needOnePublicKey]);
       return;
     }
-    
+
     if (publicKeys[0].curve_type !== 'secp256k1') {
       res.status(400).json(RosettaErrors[RosettaErrorsTypes.invalidCurveType]);
       return;

--- a/src/api/routes/rosetta/construction.ts
+++ b/src/api/routes/rosetta/construction.ts
@@ -21,6 +21,7 @@ import {
   RosettaConstructionCombineResponse,
   RosettaAmount,
   RosettaCurrency,
+  RosettaTransaction,
 } from '@blockstack/stacks-blockchain-api-types';
 import {
   createMessageSignature,
@@ -262,7 +263,7 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
     }
     const txSize: number = options.size;
 
-    let response: RosettaConstructionMetadataResponse;
+    let response = {} as RosettaConstructionMetadataResponse;
     switch (options.type) {
       case 'token_transfer':
         const recipientAddress = options.token_transfer_recipient_address;

--- a/src/api/routes/rosetta/network.ts
+++ b/src/api/routes/rosetta/network.ts
@@ -48,13 +48,13 @@ export function createRosettaNetworkRouter(db: DataStore, chainId: ChainID): Rou
       return;
     }
 
-    const block = await getRosettaBlockFromDataStore(db);
+    const block = await getRosettaBlockFromDataStore(db, false);
     if (!block.found) {
       res.status(404).json(RosettaErrors[RosettaErrorsTypes.blockNotFound]);
       return;
     }
 
-    const genesis = await getRosettaBlockFromDataStore(db, undefined, 1);
+    const genesis = await getRosettaBlockFromDataStore(db, false, undefined, 1);
     if (!genesis.found) {
       res.status(400).json(RosettaErrors[RosettaErrorsTypes.blockNotFound]);
       return;

--- a/src/datastore/common.ts
+++ b/src/datastore/common.ts
@@ -432,6 +432,14 @@ export interface DataStore extends DataStoreEventEmitter {
     limit: number;
     offset: number;
   }): Promise<{ results: AddressNftEventIdentifier[]; total: number }>;
+
+  getMinerRewards({
+    blockHeight,
+    rewardRecipient,
+  }: {
+    blockHeight: number;
+    rewardRecipient?: string;
+  }): Promise<DbMinerReward[]>;
 }
 
 export function getAssetEventId(event_index: number, event_tx_id: string): string {

--- a/src/datastore/memory-store.ts
+++ b/src/datastore/memory-store.ts
@@ -21,6 +21,7 @@ import {
   DbInboundStxTransfer,
   DbTxStatus,
   AddressNftEventIdentifier,
+  DbMinerReward,
 } from './common';
 import { logger, FoundOrNot } from '../helpers';
 import { TransactionType } from '@blockstack/stacks-blockchain-api-types';
@@ -466,5 +467,15 @@ export class MemoryDataStore extends (EventEmitter as { new (): DataStoreEventEm
     offset: number;
   }): Promise<{ results: AddressNftEventIdentifier[]; total: number }> {
     throw new Error('Method not implemented.');
+  }
+
+  getMinerRewards({
+    blockHeight,
+    rewardRecipient,
+  }: {
+    blockHeight: number;
+    rewardRecipient?: string;
+  }): Promise<DbMinerReward[]> {
+    return Promise.resolve([]);
   }
 }

--- a/src/rosetta-helpers.ts
+++ b/src/rosetta-helpers.ts
@@ -16,8 +16,7 @@ import {
   makeSigHashPreSign,
   MessageSignature,
   parseRecoverableSignature,
-  deserializeTransaction
-  PayloadType,
+  deserializeTransaction,
   StacksTransaction,
   BufferReader,
   txidFromData,
@@ -387,14 +386,14 @@ export function getOptionsFromOperations(operations: RosettaOperation[]): Rosett
         if (operation.amount && BigInt(operation.amount.value) > 0) {
           return null;
         }
-        if (!operation.metadata || typeof operation.metadata.number_of_cycles !== "number") {
+        if (!operation.metadata || typeof operation.metadata.number_of_cycles !== 'number') {
           return null;
         }
         const options: RosettaOptions = {
           sender_address: operation.account?.address,
           type: operation.type,
           status: null,
-          number_of_cycles: operation.metadata.number_of_cycles as number,
+          number_of_cycles: operation.metadata.number_of_cycles,
           burn_block_height: operation.metadata?.burn_block_height as number,
           amount: operation.amount?.value.replace('-', ''),
           symbol: operation.amount?.currency.symbol,

--- a/src/rosetta-helpers.ts
+++ b/src/rosetta-helpers.ts
@@ -173,7 +173,7 @@ function makeFeeOperation(tx: BaseTx): RosettaOperation {
   const fee: RosettaOperation = {
     operation_identifier: { index: 0 },
     type: 'fee',
-    status: getTxStatus(tx.status),
+    status: getTxStatus(DbTxStatus.Success),
     account: { address: tx.sender_address },
     amount: {
       value: (0n - tx.fee_rate).toString(10),

--- a/src/rosetta-helpers.ts
+++ b/src/rosetta-helpers.ts
@@ -59,9 +59,6 @@ export function getOperations(tx: BaseTx, events?: DbEvent[]): RosettaOperation[
       operations.push(makeFeeOperation(tx));
       operations.push(makeSenderOperation(tx, operations.length));
       operations.push(makeReceiverOperation(tx, operations.length));
-      if (events !== undefined) {
-        processEvents(events, tx, operations);
-      }
       break;
     case 'contract_call':
       operations.push(makeFeeOperation(tx));
@@ -80,6 +77,11 @@ export function getOperations(tx: BaseTx, events?: DbEvent[]): RosettaOperation[
     default:
       throw new Error(`Unexpected tx type: ${JSON.stringify(txType)}`);
   }
+
+  if (events !== undefined) {
+    processEvents(events, tx, operations);
+  }
+
   return operations;
 }
 

--- a/src/rosetta-helpers.ts
+++ b/src/rosetta-helpers.ts
@@ -116,8 +116,14 @@ export function processEvents(events: DbEvent[], baseTx: BaseTx, operations: Ros
               break;
             }
             const tx = baseTx;
-            tx.sender_address = stxAssetEvent.sender!;
-            tx.token_transfer_recipient_address = stxAssetEvent.recipient;
+            tx.sender_address = unwrapOptional(
+              stxAssetEvent.sender,
+              () => 'Unexpected nullish sender'
+            );
+            tx.token_transfer_recipient_address = unwrapOptional(
+              stxAssetEvent.recipient,
+              () => 'Unexpected nullish recipient'
+            );
             operations.push(makeSenderOperation(tx, operations.length));
             operations.push(makeReceiverOperation(tx, operations.length));
             break;

--- a/src/rosetta-helpers.ts
+++ b/src/rosetta-helpers.ts
@@ -92,6 +92,11 @@ export function processEvents(events: DbEvent[], baseTx: BaseTx, operations: Ros
         const txAssetEventType = stxAssetEvent.asset_event_type_id;
         switch (txAssetEventType) {
           case DbAssetEventTypeId.Transfer:
+            if(baseTx.type_id == DbTxTypeId.TokenTransfer) {
+              // each token_transfer has a transfer event associated with
+              // we break here to avoid operation duplication
+              break;
+            }
             const tx = baseTx;
             tx.sender_address = stxAssetEvent.sender!;
             tx.token_transfer_recipient_address = stxAssetEvent.recipient;

--- a/src/tests-rosetta/api.ts
+++ b/src/tests-rosetta/api.ts
@@ -60,7 +60,11 @@ import {
   RosettaOperationStatuses,
 } from '../api/rosetta-constants';
 import { getStacksTestnetNetwork, testnetKeys } from '../api/routes/debug';
-import { getOptionsFromOperations, getSignature, getStacksMainnetNetwork } from '../rosetta-helpers';
+import {
+  getOptionsFromOperations,
+  getSignature,
+  getStacksMainnetNetwork,
+} from '../rosetta-helpers';
 import { makeSigHashPreSign, MessageSignature } from '@stacks/transactions';
 
 describe('Rosetta API', () => {
@@ -2088,7 +2092,7 @@ describe('Rosetta API', () => {
       .post(`/rosetta/v1/construction/metadata`)
       .send(request);
 
-    console.log(JSON.parse(result.text))
+    console.log(JSON.parse(result.text));
 
     expect(result.status).toBe(200);
     expect(result.type).toBe('application/json');
@@ -2100,7 +2104,6 @@ describe('Rosetta API', () => {
     expect(JSON.parse(result.text).metadata).toHaveProperty('burn_block_height');
     expect(JSON.parse(result.text).suggested_fee.value).toBe('260');
   });
-
 
   /* rosetta construction end */
 


### PR DESCRIPTION
On this PR:
- `/block` endpoint now parses and retrieves `stx-events` of each transaction. Added support for `mint`, `burn` and `transfer` events  (improves rosetta-cli's reconciliations test). Closes #40 
-  Miner rewards are now parsed as `RosettaOperations` under the `Coinbase` transaction type of each block (improves rosetta-cli's reconciliations test).
- Added missing reference node for testnet when requesting syncing status on `network/status`
- Fixed duplicated error codes