### PR TITLE
[Rosetta] - Fix response http error code

### DIFF
--- a/src/api/routes/rosetta/account.ts
+++ b/src/api/routes/rosetta/account.ts
@@ -21,7 +21,7 @@ export function createRosettaAccountRouter(db: DataStore, chainId: ChainID): Rou
   router.postAsync('/balance', async (req, res) => {
     const valid: ValidSchema = await rosettaValidateRequest(req.originalUrl, req.body, chainId);
     if (!valid.valid) {
-      res.status(400).json(makeRosettaError(valid));
+      res.status(500).json(makeRosettaError(valid));
       return;
     }
 
@@ -32,7 +32,7 @@ export function createRosettaAccountRouter(db: DataStore, chainId: ChainID): Rou
     let blockHash: string = '0x';
 
     if (accountIdentifier === undefined) {
-      return res.status(400).json(RosettaErrors[RosettaErrorsTypes.emptyAccountIdentifier]);
+      return res.status(500).json(RosettaErrors[RosettaErrorsTypes.emptyAccountIdentifier]);
     }
 
     // we need to return the block height/hash in the response, so we
@@ -48,17 +48,17 @@ export function createRosettaAccountRouter(db: DataStore, chainId: ChainID): Rou
       }
       blockQuery = await db.getBlock(blockHash);
     } else {
-      return res.status(400).json(RosettaErrors[RosettaErrorsTypes.invalidBlockIdentifier]);
+      return res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidBlockIdentifier]);
     }
 
     if (!blockQuery.found) {
-      return res.status(400).json(RosettaErrors[RosettaErrorsTypes.blockNotFound]);
+      return res.status(500).json(RosettaErrors[RosettaErrorsTypes.blockNotFound]);
     }
 
     const block = blockQuery.result;
 
     if (blockIdentifier?.hash !== undefined && block.block_hash !== blockHash) {
-      return res.status(400).json(RosettaErrors[RosettaErrorsTypes.invalidBlockHash]);
+      return res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidBlockHash]);
     }
 
     const stxBalance = await db.getStxBalanceAtBlock(accountIdentifier.address, block.block_height);

--- a/src/api/routes/rosetta/block.ts
+++ b/src/api/routes/rosetta/block.ts
@@ -18,7 +18,7 @@ export function createRosettaBlockRouter(db: DataStore, chainId: ChainID): Route
   router.postAsync('/', async (req, res) => {
     const valid: ValidSchema = await rosettaValidateRequest(req.originalUrl, req.body, chainId);
     if (!valid.valid) {
-      res.status(400).json(makeRosettaError(valid));
+      res.status(500).json(makeRosettaError(valid));
       return;
     }
 
@@ -31,7 +31,7 @@ export function createRosettaBlockRouter(db: DataStore, chainId: ChainID): Route
     const block = await getRosettaBlockFromDataStore(db, true, block_hash, index);
 
     if (!block.found) {
-      res.status(404).json(RosettaErrors[RosettaErrorsTypes.blockNotFound]);
+      res.status(500).json(RosettaErrors[RosettaErrorsTypes.blockNotFound]);
       return;
     }
     const blockResponse: RosettaBlockResponse = {
@@ -43,7 +43,7 @@ export function createRosettaBlockRouter(db: DataStore, chainId: ChainID): Route
   router.postAsync('/transaction', async (req, res) => {
     const valid: ValidSchema = await rosettaValidateRequest(req.originalUrl, req.body, chainId);
     if (!valid.valid) {
-      res.status(400).json(makeRosettaError(valid));
+      res.status(500).json(makeRosettaError(valid));
       return;
     }
 
@@ -54,7 +54,7 @@ export function createRosettaBlockRouter(db: DataStore, chainId: ChainID): Route
 
     const transaction = await getRosettaTransactionFromDataStore(tx_hash, db);
     if (!transaction.found) {
-      res.status(404).json(RosettaErrors[RosettaErrorsTypes.transactionNotFound]);
+      res.status(500).json(RosettaErrors[RosettaErrorsTypes.transactionNotFound]);
       return;
     }
 

--- a/src/api/routes/rosetta/construction.ts
+++ b/src/api/routes/rosetta/construction.ts
@@ -82,9 +82,9 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
     if (!valid.valid) {
       //TODO have to fix this and make error generic
       if (valid.error?.includes('should be equal to one of the allowed values')) {
-        res.status(400).json(RosettaErrors[RosettaErrorsTypes.invalidCurveType]);
+        res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidCurveType]);
       }
-      res.status(400).json(makeRosettaError(valid));
+      res.status(500).json(makeRosettaError(valid));
       return;
     }
 
@@ -98,7 +98,7 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
     try {
       const btcAddress = publicKeyToBitcoinAddress(publicKey.hex_bytes, network.network);
       if (btcAddress === undefined) {
-        res.status(400).json(RosettaErrors[RosettaErrorsTypes.invalidPublicKey]);
+        res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidPublicKey]);
         return;
       }
       const stxAddress = bitcoinAddressToSTXAddress(btcAddress);
@@ -111,7 +111,7 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
       };
       res.json(response);
     } catch (e) {
-      res.status(400).json(RosettaErrors[RosettaErrorsTypes.invalidPublicKey]);
+      res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidPublicKey]);
     }
   });
 
@@ -119,7 +119,7 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
   router.postAsync('/preprocess', async (req, res) => {
     const valid: ValidSchema = await rosettaValidateRequest(req.originalUrl, req.body, chainId);
     if (!valid.valid) {
-      res.status(400).json(makeRosettaError(valid));
+      res.status(500).json(makeRosettaError(valid));
       return;
     }
 
@@ -127,23 +127,23 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
 
     // We are only supporting transfer, we should have operations length = 2
     if (operations.length > 2) {
-      res.status(400).json(RosettaErrors[RosettaErrorsTypes.invalidOperation]);
+      res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidOperation]);
       return;
     }
 
     if (!isSymbolSupported(req.body.operations)) {
-      res.status(400).json(RosettaErrors[RosettaErrorsTypes.invalidCurrencySymbol]);
+      res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidCurrencySymbol]);
       return;
     }
 
     if (!isDecimalsSupported(req.body.operations)) {
-      res.status(400).json(RosettaErrors[RosettaErrorsTypes.invalidCurrencyDecimals]);
+      res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidCurrencyDecimals]);
       return;
     }
 
     const options = getOptionsFromOperations(req.body.operations);
     if (options == null) {
-      res.status(400).json(RosettaErrors[RosettaErrorsTypes.invalidOperation]);
+      res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidOperation]);
       return;
     }
 
@@ -169,7 +169,7 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
       ) {
         options.max_fee = max_fee.value;
       } else {
-        res.status(400).json(RosettaErrors[RosettaErrorsTypes.invalidFee]);
+        res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidFee]);
         return;
       }
     }
@@ -203,7 +203,7 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
           version: versionBuffer,
         });
         if (!options.amount) {
-          res.status(400).json(RosettaErrors[RosettaErrorsTypes.invalidOperation]);
+          res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidOperation]);
           return;
         }
         const dummyStackingTx: UnsignedContractCallOptions = {
@@ -218,7 +218,7 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
         transaction = await makeUnsignedContractCall(dummyStackingTx);
         break;
       default:
-        res.status(400).json(RosettaErrors[RosettaErrorsTypes.invalidOperation]);
+        res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidOperation]);
         return;
     }
 
@@ -241,7 +241,7 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
   router.postAsync('/metadata', async (req, res) => {
     const valid: ValidSchema = await rosettaValidateRequest(req.originalUrl, req.body, chainId);
     if (!valid.valid) {
-      res.status(400).json(makeRosettaError(valid));
+      res.status(500).json(makeRosettaError(valid));
       return;
     }
 
@@ -249,16 +249,16 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
     const options: RosettaOptions = req.body.options;
 
     if (options?.sender_address && !isValidC32Address(options.sender_address)) {
-      res.status(400).json(RosettaErrors[RosettaErrorsTypes.invalidSender]);
+      res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidSender]);
       return;
     }
     if (options?.symbol !== RosettaConstants.symbol) {
-      res.status(400).json(RosettaErrors[RosettaErrorsTypes.invalidCurrencySymbol]);
+      res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidCurrencySymbol]);
       return;
     }
 
     if (options?.size === undefined) {
-      res.status(400).json(RosettaErrors[RosettaErrorsTypes.missingTransactionSize]);
+      res.status(500).json(RosettaErrors[RosettaErrorsTypes.missingTransactionSize]);
       return;
     }
     const txSize: number = options.size;
@@ -268,12 +268,12 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
       case 'token_transfer':
         const recipientAddress = options.token_transfer_recipient_address;
         if (options?.decimals !== RosettaConstants.decimals) {
-          res.status(400).json(RosettaErrors[RosettaErrorsTypes.invalidCurrencyDecimals]);
+          res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidCurrencyDecimals]);
           return;
         }
 
         if (recipientAddress == null || !isValidC32Address(recipientAddress)) {
-          res.status(400).json(RosettaErrors[RosettaErrorsTypes.invalidRecipient]);
+          res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidRecipient]);
           return;
         }
         break;
@@ -288,12 +288,12 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
         options.burn_block_height = coreInfo.burn_block_height + 3;
         break;
       default:
-        res.status(400).json(RosettaErrors[RosettaErrorsTypes.invalidTransactionType]);
+        res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidTransactionType]);
         return;
     }
 
     if (!request.public_keys || request.public_keys.length != 1) {
-      res.status(400).json(RosettaErrors[RosettaErrorsTypes.invalidPublicKey]);
+      res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidPublicKey]);
       return;
     }
 
@@ -310,17 +310,17 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
         request.network_identifier.network
       );
       if (btcAddress === undefined) {
-        res.status(400).json(RosettaErrors[RosettaErrorsTypes.invalidPublicKey]);
+        res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidPublicKey]);
         return;
       }
       stxAddress = bitcoinAddressToSTXAddress(btcAddress);
 
       if (stxAddress !== options.sender_address) {
-        res.status(400).json(RosettaErrors[RosettaErrorsTypes.invalidPublicKey]);
+        res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidPublicKey]);
         return;
       }
     } catch (e) {
-      res.status(400).json(RosettaErrors[RosettaErrorsTypes.invalidPublicKey]);
+      res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidPublicKey]);
       return;
     }
 
@@ -362,7 +362,7 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
   router.postAsync('/hash', async (req, res) => {
     const valid: ValidSchema = await rosettaValidateRequest(req.originalUrl, req.body, chainId);
     if (!valid.valid) {
-      res.status(400).json(makeRosettaError(valid));
+      res.status(500).json(makeRosettaError(valid));
       return;
     }
 
@@ -376,7 +376,7 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
     try {
       buffer = hexToBuffer(request.signed_transaction);
     } catch (error) {
-      res.status(400).json(RosettaErrors[RosettaErrorsTypes.invalidTransactionString]);
+      res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidTransactionString]);
       return;
     }
 
@@ -384,7 +384,7 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
     const hash = transaction.txid();
 
     if (!transaction.auth.spendingCondition) {
-      res.status(400).json(RosettaErrors[RosettaErrorsTypes.transactionNotSigned]);
+      res.status(500).json(RosettaErrors[RosettaErrorsTypes.transactionNotSigned]);
       return;
     }
     if (isSingleSig(transaction.auth.spendingCondition)) {
@@ -393,13 +393,13 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
         !transaction.auth.spendingCondition.signature.data ||
         emptyMessageSignature().data === transaction.auth.spendingCondition.signature.data
       ) {
-        res.status(400).json(RosettaErrors[RosettaErrorsTypes.transactionNotSigned]);
+        res.status(500).json(RosettaErrors[RosettaErrorsTypes.transactionNotSigned]);
         return;
       }
     } else {
       /**Multi-signature transaction does not have signature fields thus the transaction not signed */
       if (transaction.auth.spendingCondition.fields.length === 0) {
-        res.status(400).json(RosettaErrors[RosettaErrorsTypes.transactionNotSigned]);
+        res.status(500).json(RosettaErrors[RosettaErrorsTypes.transactionNotSigned]);
         return;
       }
     }
@@ -416,7 +416,7 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
   router.postAsync('/parse', async (req, res) => {
     const valid: ValidSchema = await rosettaValidateRequest(req.originalUrl, req.body, chainId);
     if (!valid.valid) {
-      res.status(400).json(makeRosettaError(valid));
+      res.status(500).json(makeRosettaError(valid));
       return;
     }
     let inputTx = req.body.transaction;
@@ -429,7 +429,7 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
     const transaction = rawTxToStacksTransaction(inputTx);
     const checkSigned = isSignedTransaction(transaction);
     if (signed != checkSigned) {
-      res.status(400).json(RosettaErrors[RosettaErrorsTypes.invalidParams]);
+      res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidParams]);
       return;
     }
     try {
@@ -455,7 +455,7 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
   router.postAsync('/submit', async (req, res) => {
     const valid: ValidSchema = await rosettaValidateRequest(req.originalUrl, req.body, chainId);
     if (!valid.valid) {
-      res.status(400).json(makeRosettaError(valid));
+      res.status(500).json(makeRosettaError(valid));
       return;
     }
     let transaction = req.body.signed_transaction;
@@ -468,7 +468,7 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
     try {
       buffer = hexToBuffer(transaction);
     } catch (error) {
-      res.status(400).json(RosettaErrors[RosettaErrorsTypes.invalidTransactionString]);
+      res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidTransactionString]);
       return;
     }
     try {
@@ -484,7 +484,7 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
       err.details = {
         message: e.message,
       };
-      res.status(400).json(err);
+      res.status(500).json(err);
     }
   });
 
@@ -492,43 +492,43 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
   router.postAsync('/payloads', async (req, res) => {
     const valid: ValidSchema = await rosettaValidateRequest(req.originalUrl, req.body, chainId);
     if (!valid.valid) {
-      res.status(400).json(makeRosettaError(valid));
+      res.status(500).json(makeRosettaError(valid));
       return;
     }
 
     const options = getOptionsFromOperations(req.body.operations);
     if (options == null) {
-      res.status(400).json(RosettaErrors[RosettaErrorsTypes.invalidOperation]);
+      res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidOperation]);
       return;
     }
 
     const amount = options.amount;
     if (!amount) {
-      res.status(400).json(RosettaErrors[RosettaErrorsTypes.invalidAmount]);
+      res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidAmount]);
       return;
     }
 
     if (!req.body.metadata || typeof req.body.metadata.fee !== 'string') {
-      res.status(400).json(RosettaErrors[RosettaErrorsTypes.invalidFees]);
+      res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidFees]);
       return;
     }
     const fee: string = req.body.metadata.fee;
 
     const publicKeys: RosettaPublicKey[] = req.body.public_keys;
     if (!publicKeys) {
-      res.status(400).json(RosettaErrors[RosettaErrorsTypes.emptyPublicKey]);
+      res.status(500).json(RosettaErrors[RosettaErrorsTypes.emptyPublicKey]);
       return;
     }
 
     const recipientAddress = options.token_transfer_recipient_address;
     if (!recipientAddress) {
-      res.status(400).json(RosettaErrors[RosettaErrorsTypes.invalidRecipient]);
+      res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidRecipient]);
       return;
     }
     const senderAddress = options.sender_address;
 
     if (!senderAddress) {
-      res.status(400).json(RosettaErrors[RosettaErrorsTypes.invalidSender]);
+      res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidSender]);
       return;
     }
 
@@ -543,12 +543,12 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
 
     if (publicKeys.length !== 1) {
       //TODO support multi-sig in the future.
-      res.status(400).json(RosettaErrors[RosettaErrorsTypes.needOnePublicKey]);
+      res.status(500).json(RosettaErrors[RosettaErrorsTypes.needOnePublicKey]);
       return;
     }
 
     if (publicKeys[0].curve_type !== 'secp256k1') {
-      res.status(400).json(RosettaErrors[RosettaErrorsTypes.invalidCurveType]);
+      res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidCurveType]);
       return;
     }
 
@@ -577,7 +577,7 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
           req.body.network_identifier.network
         );
         if (!poxBTCAddress) {
-          res.status(400).json(RosettaErrors[RosettaErrorsTypes.invalidPublicKey]);
+          res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidPublicKey]);
           return;
         }
         const { version, hash } = btcAddress.fromBase58Check(poxBTCAddress);
@@ -588,23 +588,23 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
           version: versionBuffer,
         });
         if (!options.amount) {
-          res.status(400).json(RosettaErrors[RosettaErrorsTypes.invalidOperation]);
+          res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidOperation]);
           return;
         }
         if (!options.contract_address) {
-          res.status(400).json(RosettaErrors[RosettaErrorsTypes.invalidOperation]);
+          res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidOperation]);
           return;
         }
         if (!options.contract_name) {
-          res.status(400).json(RosettaErrors[RosettaErrorsTypes.invalidOperation]);
+          res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidOperation]);
           return;
         }
         if (!options.burn_block_height) {
-          res.status(400).json(RosettaErrors[RosettaErrorsTypes.invalidOperation]);
+          res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidOperation]);
           return;
         }
         if (!options.number_of_cycles) {
-          res.status(400).json(RosettaErrors[RosettaErrorsTypes.invalidOperation]);
+          res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidOperation]);
           return;
         }
         const stackingTx: UnsignedContractCallOptions = {
@@ -624,7 +624,7 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
         transaction = await makeUnsignedContractCall(stackingTx);
         break;
       default:
-        res.status(400).json(RosettaErrors[RosettaErrorsTypes.invalidOperation]);
+        res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidOperation]);
         return;
     }
 
@@ -654,7 +654,7 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
   router.postAsync('/combine', async (req, res) => {
     const valid: ValidSchema = await rosettaValidateRequest(req.originalUrl, req.body, chainId);
     if (!valid.valid) {
-      res.status(400).json(makeRosettaError(valid));
+      res.status(500).json(makeRosettaError(valid));
       return;
     }
     const combineRequest: RosettaConstructionCombineRequest = req.body;
@@ -665,7 +665,7 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
     }
 
     if (signatures.length === 0) {
-      res.status(400).json(RosettaErrors[RosettaErrorsTypes.noSignatures]);
+      res.status(500).json(RosettaErrors[RosettaErrorsTypes.noSignatures]);
       return;
     }
 
@@ -676,20 +676,20 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
       unsigned_transaction_buffer = hexToBuffer(combineRequest.unsigned_transaction);
       transaction = deserializeTransaction(BufferReader.fromBuffer(unsigned_transaction_buffer));
     } catch (e) {
-      res.status(400).json(RosettaErrors[RosettaErrorsTypes.invalidTransactionString]);
+      res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidTransactionString]);
       return;
     }
 
     if (signatures.length !== 1)
-      res.status(400).json(RosettaErrors[RosettaErrorsTypes.needOnlyOneSignature]);
+      res.status(500).json(RosettaErrors[RosettaErrorsTypes.needOnlyOneSignature]);
 
     if (signatures[0].public_key.curve_type !== 'secp256k1') {
-      res.status(400).json(RosettaErrors[RosettaErrorsTypes.invalidCurveType]);
+      res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidCurveType]);
       return;
     }
     const preSignHash = makePresignHash(transaction);
     if (!preSignHash) {
-      res.status(400).json(RosettaErrors[RosettaErrorsTypes.invalidTransactionString]);
+      res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidTransactionString]);
       return;
     }
 
@@ -705,7 +705,7 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
       const hash = signatures[0].hex_bytes.slice(128) + signatures[0].hex_bytes.slice(0, -2);
       newSignature = createMessageSignature(hash);
     } catch (error) {
-      res.status(400).json(RosettaErrors[RosettaErrorsTypes.invalidSignature]);
+      res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidSignature]);
       return;
     }
 
@@ -720,7 +720,7 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
         newSignature
       )
     ) {
-      res.status(400).json(RosettaErrors[RosettaErrorsTypes.signatureNotVerified]);
+      res.status(500).json(RosettaErrors[RosettaErrorsTypes.signatureNotVerified]);
     }
 
     if (transaction.auth.spendingCondition && isSingleSig(transaction.auth.spendingCondition)) {

--- a/src/api/routes/rosetta/mempool.ts
+++ b/src/api/routes/rosetta/mempool.ts
@@ -26,7 +26,7 @@ export function createRosettaMempoolRouter(db: DataStore, chainId: ChainID): Rou
   router.postAsync('/', async (req, res) => {
     const valid: ValidSchema = await rosettaValidateRequest(req.originalUrl, req.body, chainId);
     if (!valid.valid) {
-      res.status(400).json(makeRosettaError(valid));
+      res.status(500).json(makeRosettaError(valid));
       return;
     }
 
@@ -44,7 +44,7 @@ export function createRosettaMempoolRouter(db: DataStore, chainId: ChainID): Rou
   router.postAsync('/transaction', async (req, res) => {
     const valid: ValidSchema = await rosettaValidateRequest(req.originalUrl, req.body, chainId);
     if (!valid.valid) {
-      res.status(400).json(makeRosettaError(valid));
+      res.status(500).json(makeRosettaError(valid));
       return;
     }
 
@@ -56,7 +56,7 @@ export function createRosettaMempoolRouter(db: DataStore, chainId: ChainID): Rou
     const mempoolTxQuery = await db.getMempoolTx({ txId: tx_id });
 
     if (!mempoolTxQuery.found) {
-      return res.status(404).json(RosettaErrors[RosettaErrorsTypes.transactionNotFound]);
+      return res.status(500).json(RosettaErrors[RosettaErrorsTypes.transactionNotFound]);
     }
 
     const operations = getOperations(mempoolTxQuery.result);

--- a/src/api/routes/rosetta/network.ts
+++ b/src/api/routes/rosetta/network.ts
@@ -44,19 +44,19 @@ export function createRosettaNetworkRouter(db: DataStore, chainId: ChainID): Rou
   router.postAsync('/status', async (req, res) => {
     const valid: ValidSchema = await rosettaValidateRequest(req.originalUrl, req.body, chainId);
     if (!valid.valid) {
-      res.status(400).json(makeRosettaError(valid));
+      res.status(500).json(makeRosettaError(valid));
       return;
     }
 
     const block = await getRosettaBlockFromDataStore(db, false);
     if (!block.found) {
-      res.status(404).json(RosettaErrors[RosettaErrorsTypes.blockNotFound]);
+      res.status(500).json(RosettaErrors[RosettaErrorsTypes.blockNotFound]);
       return;
     }
 
     const genesis = await getRosettaBlockFromDataStore(db, false, undefined, 1);
     if (!genesis.found) {
-      res.status(400).json(RosettaErrors[RosettaErrorsTypes.blockNotFound]);
+      res.status(500).json(RosettaErrors[RosettaErrorsTypes.blockNotFound]);
       return;
     }
 
@@ -113,7 +113,7 @@ export function createRosettaNetworkRouter(db: DataStore, chainId: ChainID): Rou
   router.postAsync('/options', async (req, res) => {
     const valid: ValidSchema = await rosettaValidateRequest(req.originalUrl, req.body, chainId);
     if (!valid.valid) {
-      res.status(400).json(makeRosettaError(valid));
+      res.status(500).json(makeRosettaError(valid));
       return;
     }
 

--- a/src/datastore/memory-store.ts
+++ b/src/datastore/memory-store.ts
@@ -570,11 +570,6 @@ export class MemoryDataStore extends (EventEmitter as { new (): DataStoreEventEm
   ): Promise<{ results: DbTx[]; total: number }> {
     throw new Error('Method not implemented');
   }
-<<<<<<< HEAD
-
-=======
-  
->>>>>>> chore: stacking feature; event processing;
   getMinerRewards({
     blockHeight,
     rewardRecipient,

--- a/src/datastore/memory-store.ts
+++ b/src/datastore/memory-store.ts
@@ -570,7 +570,11 @@ export class MemoryDataStore extends (EventEmitter as { new (): DataStoreEventEm
   ): Promise<{ results: DbTx[]; total: number }> {
     throw new Error('Method not implemented');
   }
+<<<<<<< HEAD
 
+=======
+  
+>>>>>>> chore: stacking feature; event processing;
   getMinerRewards({
     blockHeight,
     rewardRecipient,

--- a/src/tests-rosetta/api.ts
+++ b/src/tests-rosetta/api.ts
@@ -116,7 +116,7 @@ describe('Rosetta API', () => {
 
   test('network/options - bad request', async () => {
     const query1 = await supertest(api.server).post(`/rosetta/v1/network/options`).send({});
-    expect(query1.status).toBe(400);
+    expect(query1.status).toBe(500);
     expect(query1.type).toBe('application/json');
     expect(JSON.parse(query1.text)).toEqual({
       code: 613,
@@ -130,7 +130,7 @@ describe('Rosetta API', () => {
     const query1 = await supertest(api.server)
       .post(`/rosetta/v1/network/status`)
       .send({ network_identifier: { blockchain: 'bitcoin', network: 'testnet' } });
-    expect(query1.status).toBe(400);
+    expect(query1.status).toBe(500);
     expect(query1.type).toBe('application/json');
     expect(JSON.parse(query1.text)).toEqual({
       code: 611,
@@ -143,7 +143,7 @@ describe('Rosetta API', () => {
     const query1 = await supertest(api.server)
       .post(`/rosetta/v1/network/status`)
       .send({ network_identifier: { blockchain: 'stacks', network: 'mainnet' } });
-    expect(query1.status).toBe(400);
+    expect(query1.status).toBe(500);
     expect(query1.type).toBe('application/json');
     expect(JSON.parse(query1.text)).toEqual({
       code: 610,
@@ -408,7 +408,7 @@ describe('Rosetta API', () => {
         block_identifier: { index: 3, hash: '0x3a' },
         transaction_identifier: { hash: '3' },
       });
-    expect(query1.status).toBe(400);
+    expect(query1.status).toBe(500);
     expect(query1.type).toBe('application/json');
     expect(JSON.parse(query1.text)).toEqual({
       code: 608,
@@ -636,7 +636,7 @@ describe('Rosetta API', () => {
     };
 
     const result = await supertest(api.server).post(`/rosetta/v1/account/balance/`).send(request);
-    expect(result.status).toBe(400);
+    expect(result.status).toBe(500);
     expect(result.type).toBe('application/json');
 
     const expectResponse = {
@@ -662,7 +662,7 @@ describe('Rosetta API', () => {
     };
 
     const result = await supertest(api.server).post(`/rosetta/v1/account/balance/`).send(request);
-    expect(result.status).toBe(400);
+    expect(result.status).toBe(500);
     expect(result.type).toBe('application/json');
 
     const expectResponse = {
@@ -689,7 +689,7 @@ describe('Rosetta API', () => {
       },
     };
     const result = await supertest(api.server).post(`/rosetta/v1/account/balance/`).send(request);
-    expect(result.status).toBe(400);
+    expect(result.status).toBe(500);
     expect(result.type).toBe('application/json');
 
     const expectResponse = {
@@ -745,7 +745,7 @@ describe('Rosetta API', () => {
     const result2 = await supertest(api.server)
       .post(`/rosetta/v1/construction/derive`)
       .send(request2);
-    expect(result2.status).toBe(400);
+    expect(result2.status).toBe(500);
 
     const expectedResponse2 = RosettaErrors[RosettaErrorsTypes.invalidCurveType];
 
@@ -765,7 +765,7 @@ describe('Rosetta API', () => {
     const result3 = await supertest(api.server)
       .post(`/rosetta/v1/construction/derive`)
       .send(request3);
-    expect(result3.status).toBe(400);
+    expect(result3.status).toBe(500);
 
     const expectedResponse3 = RosettaErrors[RosettaErrorsTypes.invalidPublicKey];
 
@@ -933,7 +933,7 @@ describe('Rosetta API', () => {
     const result2 = await supertest(api.server)
       .post(`/rosetta/v1/construction/preprocess`)
       .send(request2);
-    expect(result2.status).toBe(400);
+    expect(result2.status).toBe(500);
 
     const expectedResponse2 = RosettaErrors[RosettaErrorsTypes.invalidOperation];
 
@@ -1009,7 +1009,7 @@ describe('Rosetta API', () => {
       .post(`/rosetta/v1/construction/metadata`)
       .send(request);
 
-    expect(result.status).toBe(400);
+    expect(result.status).toBe(500);
     expect(result.type).toBe('application/json');
 
     expect(JSON.parse(result.text)).toEqual(RosettaErrors[RosettaErrorsTypes.invalidPublicKey]);
@@ -1034,7 +1034,7 @@ describe('Rosetta API', () => {
       .post(`/rosetta/v1/construction/metadata`)
       .send(request);
 
-    expect(result.status).toBe(400);
+    expect(result.status).toBe(500);
     expect(result.type).toBe('application/json');
 
     const expectResponse = {
@@ -1072,7 +1072,7 @@ describe('Rosetta API', () => {
       .post(`/rosetta/v1/construction/metadata`)
       .send(request);
 
-    expect(result.status).toBe(400);
+    expect(result.status).toBe(500);
     expect(result.type).toBe('application/json');
 
     const expectResponse = {
@@ -1108,7 +1108,7 @@ describe('Rosetta API', () => {
       .post(`/rosetta/v1/construction/metadata`)
       .send(request);
 
-    expect(result.status).toBe(400);
+    expect(result.status).toBe(500);
     expect(result.type).toBe('application/json');
 
     const expectResponse = {
@@ -1143,7 +1143,7 @@ describe('Rosetta API', () => {
       .post(`/rosetta/v1/construction/metadata`)
       .send(request);
 
-    expect(result.status).toBe(400);
+    expect(result.status).toBe(500);
     expect(result.type).toBe('application/json');
 
     const expectResponse = {
@@ -1210,7 +1210,7 @@ describe('Rosetta API', () => {
     };
 
     const result = await supertest(api.server).post(`/rosetta/v1/construction/hash`).send(request);
-    expect(result.status).toBe(400);
+    expect(result.status).toBe(500);
 
     const expectedResponse = RosettaErrors[RosettaErrorsTypes.invalidTransactionString];
 
@@ -1229,7 +1229,7 @@ describe('Rosetta API', () => {
     };
 
     const result = await supertest(api.server).post(`/rosetta/v1/construction/hash`).send(request);
-    expect(result.status).toBe(400);
+    expect(result.status).toBe(500);
 
     const expectedResponse = RosettaErrors[RosettaErrorsTypes.transactionNotSigned];
 
@@ -1373,7 +1373,7 @@ describe('Rosetta API', () => {
     const result = await supertest(api.server)
       .post(`/rosetta/v1/construction/submit`)
       .send(request);
-    expect(result.status).toBe(400);
+    expect(result.status).toBe(500);
     const expectedResponse = RosettaErrors[RosettaErrorsTypes.invalidTransactionString];
 
     console.log(expectedResponse);
@@ -1566,7 +1566,7 @@ describe('Rosetta API', () => {
       .post(`/rosetta/v1/construction/payloads`)
       .send(request);
 
-    expect(result.status).toBe(400);
+    expect(result.status).toBe(500);
     expect(result.type).toBe('application/json');
 
     const expectedResponse = RosettaErrors[RosettaErrorsTypes.needOnePublicKey];
@@ -1633,7 +1633,7 @@ describe('Rosetta API', () => {
       .post(`/rosetta/v1/construction/payloads`)
       .send(request);
 
-    expect(result.status).toBe(400);
+    expect(result.status).toBe(500);
     expect(result.type).toBe('application/json');
 
     const expectedResponse = RosettaErrors[RosettaErrorsTypes.emptyPublicKey];
@@ -1706,7 +1706,7 @@ describe('Rosetta API', () => {
       .post(`/rosetta/v1/construction/payloads`)
       .send(request);
 
-    expect(result.status).toBe(400);
+    expect(result.status).toBe(500);
     expect(result.type).toBe('application/json');
 
     const expectedResponse = RosettaErrors[RosettaErrorsTypes.invalidCurveType];
@@ -1825,7 +1825,7 @@ describe('Rosetta API', () => {
       .post(`/rosetta/v1/construction/combine`)
       .send(request);
 
-    expect(result.status).toBe(400);
+    expect(result.status).toBe(500);
     expect(result.type).toBe('application/json');
 
     const expectedResponse = RosettaErrors[RosettaErrorsTypes.needOnlyOneSignature];
@@ -1862,7 +1862,7 @@ describe('Rosetta API', () => {
       .post(`/rosetta/v1/construction/combine`)
       .send(request);
 
-    expect(result.status).toBe(400);
+    expect(result.status).toBe(500);
     expect(result.type).toBe('application/json');
 
     const expectedResponse = RosettaErrors[RosettaErrorsTypes.invalidTransactionString];
@@ -1898,7 +1898,7 @@ describe('Rosetta API', () => {
       .post(`/rosetta/v1/construction/combine`)
       .send(request);
 
-    expect(result.status).toBe(400);
+    expect(result.status).toBe(500);
     expect(result.type).toBe('application/json');
 
     const expectedResponse = RosettaErrors[RosettaErrorsTypes.invalidSignature];
@@ -1954,7 +1954,7 @@ describe('Rosetta API', () => {
       .post(`/rosetta/v1/construction/combine`)
       .send(request);
 
-    expect(result.status).toBe(400);
+    expect(result.status).toBe(500);
     expect(result.type).toBe('application/json');
 
     const expectedResponse = RosettaErrors[RosettaErrorsTypes.signatureNotVerified];
@@ -1992,7 +1992,7 @@ describe('Rosetta API', () => {
       .post(`/rosetta/v1/construction/combine`)
       .send(request);
 
-    expect(result.status).toBe(400);
+    expect(result.status).toBe(500);
     expect(result.type).toBe('application/json');
 
     const expectedResponse = RosettaErrors[RosettaErrorsTypes.signatureNotVerified];


### PR DESCRIPTION
On this PR:
- fix: use http error code 500 for all rosetta errors. Closes #47 

According to rosetta docs, all errors returned by the rosetta-api must have the http error code `500`