### PR TITLE
[Rosetta-api] - Add vesting info

### DIFF
--- a/docs/api/rosetta/rosetta-construction-metadata-response.schema.json
+++ b/docs/api/rosetta/rosetta-construction-metadata-response.schema.json
@@ -19,7 +19,10 @@
       }
     },
     "suggested_fee": {
-      "$ref": "./../../entities/rosetta/rosetta-amount.schema.json"
+      "type": "array",
+      "items": {
+        "$ref": "./../../entities/rosetta/rosetta-amount.schema.json"
+      }
     }
   }
 }

--- a/docs/entities/rosetta/rosetta-operation.schema.json
+++ b/docs/entities/rosetta/rosetta-operation.schema.json
@@ -2,7 +2,7 @@
   "type": "object",
   "title": "RosettaOperation",
   "description": "Operations contain all balance-changing information within a transaction. They are always one-sided (only affect 1 AccountIdentifier) and can succeed or fail independently from a Transaction.",
-  "required": ["operation_identifier", "type", "status"],
+  "required": ["operation_identifier", "type"],
   "properties": {
     "operation_identifier": {
       "description": "The operation_identifier uniquely identifies an operation within a transaction.",
@@ -20,7 +20,7 @@
       "description": "The network-specific type of the operation. Ensure that any type that can be returned here is also specified in the NetworkStatus. This can be very useful to downstream consumers that parse all block data."
     },
     "status": {
-      "type": ["string", "null"],
+      "type": "string",
       "description": "The network-specific status of the operation. Status is not defined on the transaction object because blockchains with smart contracts may have transactions that partially apply. Blockchains with atomic transactions (all operations succeed or all operations fail) will have the same status for each operation."
     },
     "account": {

--- a/docs/index.d.ts
+++ b/docs/index.d.ts
@@ -1090,16 +1090,16 @@ export interface PostCoreNodeTransactionsError {
 export interface AddressTransactionWithTransfers {
   tx: Transaction;
   /**
-   * Total STX sent from the given address, including the tx fee
+   * Total sent from the given address, including the tx fee, in micro-STX as an integer string.
    */
   stx_sent: string;
   /**
-   * Total STX received by the given address
+   * Total received by the given address in micro-STX as an integer string.
    */
   stx_received: string;
   stx_transfers: {
     /**
-     * STX amount transferred
+     * Amount transferred in micro-STX as an integer string.
      */
     amount: string;
     /**

--- a/docs/index.d.ts
+++ b/docs/index.d.ts
@@ -765,7 +765,7 @@ export interface RosettaConstructionMetadataResponse {
     recent_block_hash?: string;
     [k: string]: unknown | undefined;
   };
-  suggested_fee?: RosettaAmount;
+  suggested_fee?: RosettaAmount[];
 }
 
 /**
@@ -2009,7 +2009,7 @@ export interface RosettaOperation {
   /**
    * The network-specific status of the operation. Status is not defined on the transaction object because blockchains with smart contracts may have transactions that partially apply. Blockchains with atomic transactions (all operations succeed or all operations fail) will have the same status for each operation.
    */
-  status: string | null;
+  status?: string;
   account?: RosettaAccount;
   amount?: RosettaAmount;
   coin_change?: RosettaCoinChange;

--- a/src/api/controllers/db-controller.ts
+++ b/src/api/controllers/db-controller.ts
@@ -126,9 +126,9 @@ export function getTxStatusString(
   }
 }
 
-export function getTxStatus(txStatus: DbTxStatus | string): string | null {
+export function getTxStatus(txStatus: DbTxStatus | string): string {
   if (txStatus == '') {
-    return null;
+    return '';
   } else {
     return getTxStatusString(txStatus as DbTxStatus);
   }

--- a/src/api/rosetta-constants.ts
+++ b/src/api/rosetta-constants.ts
@@ -12,12 +12,11 @@ export const RosettaConstants = {
   rosettaVersion: '1.4.6',
   symbol: 'STX',
   decimals: 6,
-  lockedBalance: 'LockedBalance',
-  spendableBalance: 'SpendableBalance',
-  vestedBalance: 'VestedBalance',
-  vestingTotalLockedKey: 'vesting_total_locked',
-  vestingTotalUnlockedKey: 'vesting_total_unlocked',
-  vestingScheduleKey: 'vesting_schedule',
+  StakedBalance: 'StakedBalance',
+  SpendableBalance: 'SpendableBalance',
+  VestingLockedBalance: 'VestingLockedBalance',
+  VestingUnlockedBalance: 'VestingUnlockedBalance',
+  VestingSchedule: 'VestingSchedule',
 };
 
 export const ReferenceNodes: { [key: string]: any } = {
@@ -51,6 +50,7 @@ export const RosettaOperationTypes = [
   'mint',
   'burn',
   'miner_reward',
+  'stx_lock',
 ];
 
 export const RosettaOperationStatuses = [

--- a/src/api/rosetta-constants.ts
+++ b/src/api/rosetta-constants.ts
@@ -14,6 +14,10 @@ export const RosettaConstants = {
   decimals: 6,
   lockedBalance: 'LockedBalance',
   spendableBalance: 'SpendableBalance',
+  vestedBalance: 'VestedBalance',
+  vestingTotalLockedKey: 'vesting_total_locked',
+  vestingTotalUnlockedKey: 'vesting_total_unlocked',
+  vestingScheduleKey: 'vesting_schedule',
 };
 
 export const ReferenceNodes: { [key: string]: any } = {
@@ -109,6 +113,7 @@ export enum RosettaErrorsTypes {
   signatureTypeNotSupported,
   missingTransactionSize,
   stackingEligibityError,
+  invalidSubAccount,
 }
 
 // All possible errors
@@ -318,6 +323,11 @@ export const RosettaErrors: Record<RosettaErrorsTypes, RosettaError> = {
   [RosettaErrorsTypes.stackingEligibityError]: {
     code: 640,
     message: 'Account not eligible for stacking.',
+    retriable: false,
+  },
+  [RosettaErrorsTypes.invalidSubAccount]: {
+    code: 641,
+    message: 'Invalid sub-account',
     retriable: false,
   },
 };

--- a/src/api/routes/rosetta/account.ts
+++ b/src/api/routes/rosetta/account.ts
@@ -21,7 +21,7 @@ export function createRosettaAccountRouter(db: DataStore, chainId: ChainID): Rou
   router.postAsync('/balance', async (req, res) => {
     const valid: ValidSchema = await rosettaValidateRequest(req.originalUrl, req.body, chainId);
     if (!valid.valid) {
-      res.status(400).json(makeRosettaError(valid));
+      res.status(500).json(makeRosettaError(valid));
       return;
     }
 
@@ -32,7 +32,7 @@ export function createRosettaAccountRouter(db: DataStore, chainId: ChainID): Rou
     let blockHash: string = '0x';
 
     if (accountIdentifier === undefined) {
-      return res.status(400).json(RosettaErrors[RosettaErrorsTypes.emptyAccountIdentifier]);
+      return res.status(500).json(RosettaErrors[RosettaErrorsTypes.emptyAccountIdentifier]);
     }
 
     // we need to return the block height/hash in the response, so we
@@ -48,17 +48,17 @@ export function createRosettaAccountRouter(db: DataStore, chainId: ChainID): Rou
       }
       blockQuery = await db.getBlock(blockHash);
     } else {
-      return res.status(400).json(RosettaErrors[RosettaErrorsTypes.invalidBlockIdentifier]);
+      return res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidBlockIdentifier]);
     }
 
     if (!blockQuery.found) {
-      return res.status(400).json(RosettaErrors[RosettaErrorsTypes.blockNotFound]);
+      return res.status(500).json(RosettaErrors[RosettaErrorsTypes.blockNotFound]);
     }
 
     const block = blockQuery.result;
 
     if (blockIdentifier?.hash !== undefined && block.block_hash !== blockHash) {
-      return res.status(400).json(RosettaErrors[RosettaErrorsTypes.invalidBlockHash]);
+      return res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidBlockHash]);
     }
 
     const stxBalance = await db.getStxBalanceAtBlock(accountIdentifier.address, block.block_height);

--- a/src/api/routes/rosetta/account.ts
+++ b/src/api/routes/rosetta/account.ts
@@ -108,9 +108,7 @@ export function createRosettaAccountRouter(db: DataStore, chainId: ChainID): Rou
             symbol: RosettaConstants.symbol,
             decimals: RosettaConstants.decimals,
           },
-          metadata: {
-            ...extra_metadata,
-          },
+          metadata: Object.keys(extra_metadata).length > 0 ? extra_metadata : undefined,
         },
       ],
       metadata: {

--- a/src/api/routes/rosetta/account.ts
+++ b/src/api/routes/rosetta/account.ts
@@ -67,7 +67,7 @@ export function createRosettaAccountRouter(db: DataStore, chainId: ChainID): Rou
 
     const accountInfo = await new StacksCoreRpcClient().getAccount(accountIdentifier.address);
 
-    let extra_metadata: any = {};
+    const extra_metadata: any = {};
 
     if (subAccountIdentifier !== undefined) {
       switch (subAccountIdentifier.address) {
@@ -84,10 +84,11 @@ export function createRosettaAccountRouter(db: DataStore, chainId: ChainID): Rou
           const stxVesting = await db.getTokenOfferingLocked(accountIdentifier.address);
           if (stxVesting.found) {
             const vestingInfo = getVestingInfo(stxVesting.result, block.block_height);
-            balance = vestingInfo[subAccountIdentifier.address].toString()
-            extra_metadata[RosettaConstants.VestingSchedule] = vestingInfo[RosettaConstants.VestingSchedule]
+            balance = vestingInfo[subAccountIdentifier.address].toString();
+            extra_metadata[RosettaConstants.VestingSchedule] =
+              vestingInfo[RosettaConstants.VestingSchedule];
           } else {
-            balance = "0"
+            balance = '0';
           }
           break;
         default:

--- a/src/api/routes/rosetta/block.ts
+++ b/src/api/routes/rosetta/block.ts
@@ -18,7 +18,7 @@ export function createRosettaBlockRouter(db: DataStore, chainId: ChainID): Route
   router.postAsync('/', async (req, res) => {
     const valid: ValidSchema = await rosettaValidateRequest(req.originalUrl, req.body, chainId);
     if (!valid.valid) {
-      res.status(400).json(makeRosettaError(valid));
+      res.status(500).json(makeRosettaError(valid));
       return;
     }
 
@@ -31,7 +31,7 @@ export function createRosettaBlockRouter(db: DataStore, chainId: ChainID): Route
     const block = await getRosettaBlockFromDataStore(db, true, block_hash, index);
 
     if (!block.found) {
-      res.status(404).json(RosettaErrors[RosettaErrorsTypes.blockNotFound]);
+      res.status(500).json(RosettaErrors[RosettaErrorsTypes.blockNotFound]);
       return;
     }
     const blockResponse: RosettaBlockResponse = {
@@ -43,7 +43,7 @@ export function createRosettaBlockRouter(db: DataStore, chainId: ChainID): Route
   router.postAsync('/transaction', async (req, res) => {
     const valid: ValidSchema = await rosettaValidateRequest(req.originalUrl, req.body, chainId);
     if (!valid.valid) {
-      res.status(400).json(makeRosettaError(valid));
+      res.status(500).json(makeRosettaError(valid));
       return;
     }
 
@@ -54,7 +54,7 @@ export function createRosettaBlockRouter(db: DataStore, chainId: ChainID): Route
 
     const transaction = await getRosettaTransactionFromDataStore(tx_hash, db);
     if (!transaction.found) {
-      res.status(404).json(RosettaErrors[RosettaErrorsTypes.transactionNotFound]);
+      res.status(500).json(RosettaErrors[RosettaErrorsTypes.transactionNotFound]);
       return;
     }
 

--- a/src/api/routes/rosetta/construction.ts
+++ b/src/api/routes/rosetta/construction.ts
@@ -82,9 +82,9 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
     if (!valid.valid) {
       //TODO have to fix this and make error generic
       if (valid.error?.includes('should be equal to one of the allowed values')) {
-        res.status(400).json(RosettaErrors[RosettaErrorsTypes.invalidCurveType]);
+        res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidCurveType]);
       }
-      res.status(400).json(makeRosettaError(valid));
+      res.status(500).json(makeRosettaError(valid));
       return;
     }
 
@@ -98,7 +98,7 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
     try {
       const btcAddress = publicKeyToBitcoinAddress(publicKey.hex_bytes, network.network);
       if (btcAddress === undefined) {
-        res.status(400).json(RosettaErrors[RosettaErrorsTypes.invalidPublicKey]);
+        res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidPublicKey]);
         return;
       }
       const stxAddress = bitcoinAddressToSTXAddress(btcAddress);
@@ -111,7 +111,7 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
       };
       res.json(response);
     } catch (e) {
-      res.status(400).json(RosettaErrors[RosettaErrorsTypes.invalidPublicKey]);
+      res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidPublicKey]);
     }
   });
 
@@ -119,7 +119,7 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
   router.postAsync('/preprocess', async (req, res) => {
     const valid: ValidSchema = await rosettaValidateRequest(req.originalUrl, req.body, chainId);
     if (!valid.valid) {
-      res.status(400).json(makeRosettaError(valid));
+      res.status(500).json(makeRosettaError(valid));
       return;
     }
 
@@ -127,23 +127,23 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
 
     // We are only supporting transfer, we should have operations length = 2
     if (operations.length > 2) {
-      res.status(400).json(RosettaErrors[RosettaErrorsTypes.invalidOperation]);
+      res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidOperation]);
       return;
     }
 
     if (!isSymbolSupported(req.body.operations)) {
-      res.status(400).json(RosettaErrors[RosettaErrorsTypes.invalidCurrencySymbol]);
+      res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidCurrencySymbol]);
       return;
     }
 
     if (!isDecimalsSupported(req.body.operations)) {
-      res.status(400).json(RosettaErrors[RosettaErrorsTypes.invalidCurrencyDecimals]);
+      res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidCurrencyDecimals]);
       return;
     }
 
     const options = getOptionsFromOperations(req.body.operations);
     if (options == null) {
-      res.status(400).json(RosettaErrors[RosettaErrorsTypes.invalidOperation]);
+      res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidOperation]);
       return;
     }
 
@@ -169,7 +169,7 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
       ) {
         options.max_fee = max_fee.value;
       } else {
-        res.status(400).json(RosettaErrors[RosettaErrorsTypes.invalidFee]);
+        res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidFee]);
         return;
       }
     }
@@ -203,7 +203,7 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
           version: versionBuffer,
         });
         if (!options.amount) {
-          res.status(400).json(RosettaErrors[RosettaErrorsTypes.invalidOperation]);
+          res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidOperation]);
           return;
         }
         const dummyStackingTx: UnsignedContractCallOptions = {
@@ -218,7 +218,7 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
         transaction = await makeUnsignedContractCall(dummyStackingTx);
         break;
       default:
-        res.status(400).json(RosettaErrors[RosettaErrorsTypes.invalidOperation]);
+        res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidOperation]);
         return;
     }
 
@@ -241,7 +241,7 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
   router.postAsync('/metadata', async (req, res) => {
     const valid: ValidSchema = await rosettaValidateRequest(req.originalUrl, req.body, chainId);
     if (!valid.valid) {
-      res.status(400).json(makeRosettaError(valid));
+      res.status(500).json(makeRosettaError(valid));
       return;
     }
 
@@ -249,16 +249,16 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
     const options: RosettaOptions = req.body.options;
 
     if (options?.sender_address && !isValidC32Address(options.sender_address)) {
-      res.status(400).json(RosettaErrors[RosettaErrorsTypes.invalidSender]);
+      res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidSender]);
       return;
     }
     if (options?.symbol !== RosettaConstants.symbol) {
-      res.status(400).json(RosettaErrors[RosettaErrorsTypes.invalidCurrencySymbol]);
+      res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidCurrencySymbol]);
       return;
     }
 
     if (options?.size === undefined) {
-      res.status(400).json(RosettaErrors[RosettaErrorsTypes.missingTransactionSize]);
+      res.status(500).json(RosettaErrors[RosettaErrorsTypes.missingTransactionSize]);
       return;
     }
     const txSize: number = options.size;
@@ -268,12 +268,12 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
       case 'token_transfer':
         const recipientAddress = options.token_transfer_recipient_address;
         if (options?.decimals !== RosettaConstants.decimals) {
-          res.status(400).json(RosettaErrors[RosettaErrorsTypes.invalidCurrencyDecimals]);
+          res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidCurrencyDecimals]);
           return;
         }
 
         if (recipientAddress == null || !isValidC32Address(recipientAddress)) {
-          res.status(400).json(RosettaErrors[RosettaErrorsTypes.invalidRecipient]);
+          res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidRecipient]);
           return;
         }
         break;
@@ -288,12 +288,12 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
         options.burn_block_height = coreInfo.burn_block_height + 3;
         break;
       default:
-        res.status(400).json(RosettaErrors[RosettaErrorsTypes.invalidTransactionType]);
+        res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidTransactionType]);
         return;
     }
 
     if (!request.public_keys || request.public_keys.length != 1) {
-      res.status(400).json(RosettaErrors[RosettaErrorsTypes.invalidPublicKey]);
+      res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidPublicKey]);
       return;
     }
 
@@ -310,17 +310,17 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
         request.network_identifier.network
       );
       if (btcAddress === undefined) {
-        res.status(400).json(RosettaErrors[RosettaErrorsTypes.invalidPublicKey]);
+        res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidPublicKey]);
         return;
       }
       stxAddress = bitcoinAddressToSTXAddress(btcAddress);
 
       if (stxAddress !== options.sender_address) {
-        res.status(400).json(RosettaErrors[RosettaErrorsTypes.invalidPublicKey]);
+        res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidPublicKey]);
         return;
       }
     } catch (e) {
-      res.status(400).json(RosettaErrors[RosettaErrorsTypes.invalidPublicKey]);
+      res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidPublicKey]);
       return;
     }
 
@@ -362,7 +362,7 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
   router.postAsync('/hash', async (req, res) => {
     const valid: ValidSchema = await rosettaValidateRequest(req.originalUrl, req.body, chainId);
     if (!valid.valid) {
-      res.status(400).json(makeRosettaError(valid));
+      res.status(500).json(makeRosettaError(valid));
       return;
     }
 
@@ -376,7 +376,7 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
     try {
       buffer = hexToBuffer(request.signed_transaction);
     } catch (error) {
-      res.status(400).json(RosettaErrors[RosettaErrorsTypes.invalidTransactionString]);
+      res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidTransactionString]);
       return;
     }
 
@@ -384,7 +384,7 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
     const hash = transaction.txid();
 
     if (!transaction.auth.spendingCondition) {
-      res.status(400).json(RosettaErrors[RosettaErrorsTypes.transactionNotSigned]);
+      res.status(500).json(RosettaErrors[RosettaErrorsTypes.transactionNotSigned]);
       return;
     }
     if (isSingleSig(transaction.auth.spendingCondition)) {
@@ -393,13 +393,13 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
         !transaction.auth.spendingCondition.signature.data ||
         emptyMessageSignature().data === transaction.auth.spendingCondition.signature.data
       ) {
-        res.status(400).json(RosettaErrors[RosettaErrorsTypes.transactionNotSigned]);
+        res.status(500).json(RosettaErrors[RosettaErrorsTypes.transactionNotSigned]);
         return;
       }
     } else {
       /**Multi-signature transaction does not have signature fields thus the transaction not signed */
       if (transaction.auth.spendingCondition.fields.length === 0) {
-        res.status(400).json(RosettaErrors[RosettaErrorsTypes.transactionNotSigned]);
+        res.status(500).json(RosettaErrors[RosettaErrorsTypes.transactionNotSigned]);
         return;
       }
     }
@@ -416,7 +416,7 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
   router.postAsync('/parse', async (req, res) => {
     const valid: ValidSchema = await rosettaValidateRequest(req.originalUrl, req.body, chainId);
     if (!valid.valid) {
-      res.status(400).json(makeRosettaError(valid));
+      res.status(500).json(makeRosettaError(valid));
       return;
     }
     let inputTx = req.body.transaction;
@@ -429,7 +429,7 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
     const transaction = rawTxToStacksTransaction(inputTx);
     const checkSigned = isSignedTransaction(transaction);
     if (signed != checkSigned) {
-      res.status(400).json(RosettaErrors[RosettaErrorsTypes.invalidParams]);
+      res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidParams]);
       return;
     }
     try {
@@ -455,7 +455,7 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
   router.postAsync('/submit', async (req, res) => {
     const valid: ValidSchema = await rosettaValidateRequest(req.originalUrl, req.body, chainId);
     if (!valid.valid) {
-      res.status(400).json(makeRosettaError(valid));
+      res.status(500).json(makeRosettaError(valid));
       return;
     }
     let transaction = req.body.signed_transaction;
@@ -468,7 +468,7 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
     try {
       buffer = hexToBuffer(transaction);
     } catch (error) {
-      res.status(400).json(RosettaErrors[RosettaErrorsTypes.invalidTransactionString]);
+      res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidTransactionString]);
       return;
     }
     try {
@@ -484,7 +484,7 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
       err.details = {
         message: e.message,
       };
-      res.status(400).json(err);
+      res.status(500).json(err);
     }
   });
 
@@ -492,43 +492,43 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
   router.postAsync('/payloads', async (req, res) => {
     const valid: ValidSchema = await rosettaValidateRequest(req.originalUrl, req.body, chainId);
     if (!valid.valid) {
-      res.status(400).json(makeRosettaError(valid));
+      res.status(500).json(makeRosettaError(valid));
       return;
     }
 
     const options = getOptionsFromOperations(req.body.operations);
     if (options == null) {
-      res.status(400).json(RosettaErrors[RosettaErrorsTypes.invalidOperation]);
+      res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidOperation]);
       return;
     }
 
     const amount = options.amount;
     if (!amount) {
-      res.status(400).json(RosettaErrors[RosettaErrorsTypes.invalidAmount]);
+      res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidAmount]);
       return;
     }
 
     if (!req.body.metadata || typeof req.body.metadata.fee !== 'string') {
-      res.status(400).json(RosettaErrors[RosettaErrorsTypes.invalidFees]);
+      res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidFees]);
       return;
     }
     const fee: string = req.body.metadata.fee;
 
     const publicKeys: RosettaPublicKey[] = req.body.public_keys;
     if (!publicKeys) {
-      res.status(400).json(RosettaErrors[RosettaErrorsTypes.emptyPublicKey]);
+      res.status(500).json(RosettaErrors[RosettaErrorsTypes.emptyPublicKey]);
       return;
     }
 
     const recipientAddress = options.token_transfer_recipient_address;
     if (!recipientAddress) {
-      res.status(400).json(RosettaErrors[RosettaErrorsTypes.invalidRecipient]);
+      res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidRecipient]);
       return;
     }
     const senderAddress = options.sender_address;
 
     if (!senderAddress) {
-      res.status(400).json(RosettaErrors[RosettaErrorsTypes.invalidSender]);
+      res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidSender]);
       return;
     }
 
@@ -543,12 +543,12 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
 
     if (publicKeys.length !== 1) {
       //TODO support multi-sig in the future.
-      res.status(400).json(RosettaErrors[RosettaErrorsTypes.needOnePublicKey]);
+      res.status(500).json(RosettaErrors[RosettaErrorsTypes.needOnePublicKey]);
       return;
     }
 
     if (publicKeys[0].curve_type !== 'secp256k1') {
-      res.status(400).json(RosettaErrors[RosettaErrorsTypes.invalidCurveType]);
+      res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidCurveType]);
       return;
     }
 
@@ -577,7 +577,7 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
           req.body.network_identifier.network
         );
         if (!poxBTCAddress) {
-          res.status(400).json(RosettaErrors[RosettaErrorsTypes.invalidPublicKey]);
+          res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidPublicKey]);
           return;
         }
         const { version, hash } = btcAddress.fromBase58Check(poxBTCAddress);
@@ -588,23 +588,23 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
           version: versionBuffer,
         });
         if (!options.amount) {
-          res.status(400).json(RosettaErrors[RosettaErrorsTypes.invalidOperation]);
+          res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidOperation]);
           return;
         }
         if (!options.contract_address) {
-          res.status(400).json(RosettaErrors[RosettaErrorsTypes.invalidOperation]);
+          res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidOperation]);
           return;
         }
         if (!options.contract_name) {
-          res.status(400).json(RosettaErrors[RosettaErrorsTypes.invalidOperation]);
+          res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidOperation]);
           return;
         }
         if (!options.burn_block_height) {
-          res.status(400).json(RosettaErrors[RosettaErrorsTypes.invalidOperation]);
+          res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidOperation]);
           return;
         }
         if (!options.number_of_cycles) {
-          res.status(400).json(RosettaErrors[RosettaErrorsTypes.invalidOperation]);
+          res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidOperation]);
           return;
         }
         const stackingTx: UnsignedContractCallOptions = {
@@ -624,7 +624,7 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
         transaction = await makeUnsignedContractCall(stackingTx);
         break;
       default:
-        res.status(400).json(RosettaErrors[RosettaErrorsTypes.invalidOperation]);
+        res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidOperation]);
         return;
     }
 
@@ -654,7 +654,7 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
   router.postAsync('/combine', async (req, res) => {
     const valid: ValidSchema = await rosettaValidateRequest(req.originalUrl, req.body, chainId);
     if (!valid.valid) {
-      res.status(400).json(makeRosettaError(valid));
+      res.status(500).json(makeRosettaError(valid));
       return;
     }
     const combineRequest: RosettaConstructionCombineRequest = req.body;
@@ -665,7 +665,7 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
     }
 
     if (signatures.length === 0) {
-      res.status(400).json(RosettaErrors[RosettaErrorsTypes.noSignatures]);
+      res.status(500).json(RosettaErrors[RosettaErrorsTypes.noSignatures]);
       return;
     }
 
@@ -676,20 +676,20 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
       unsigned_transaction_buffer = hexToBuffer(combineRequest.unsigned_transaction);
       transaction = deserializeTransaction(BufferReader.fromBuffer(unsigned_transaction_buffer));
     } catch (e) {
-      res.status(400).json(RosettaErrors[RosettaErrorsTypes.invalidTransactionString]);
+      res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidTransactionString]);
       return;
     }
 
     if (signatures.length !== 1)
-      res.status(400).json(RosettaErrors[RosettaErrorsTypes.needOnlyOneSignature]);
+      res.status(500).json(RosettaErrors[RosettaErrorsTypes.needOnlyOneSignature]);
 
     if (signatures[0].public_key.curve_type !== 'secp256k1') {
-      res.status(400).json(RosettaErrors[RosettaErrorsTypes.invalidCurveType]);
+      res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidCurveType]);
       return;
     }
     const preSignHash = makePresignHash(transaction);
     if (!preSignHash) {
-      res.status(400).json(RosettaErrors[RosettaErrorsTypes.invalidTransactionString]);
+      res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidTransactionString]);
       return;
     }
 
@@ -705,7 +705,7 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
       const hash = signatures[0].hex_bytes.slice(128) + signatures[0].hex_bytes.slice(0, -2);
       newSignature = createMessageSignature(hash);
     } catch (error) {
-      res.status(400).json(RosettaErrors[RosettaErrorsTypes.invalidSignature]);
+      res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidSignature]);
       return;
     }
 
@@ -720,7 +720,7 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
         newSignature
       )
     ) {
-      res.status(400).json(RosettaErrors[RosettaErrorsTypes.signatureNotVerified]);
+      res.status(500).json(RosettaErrors[RosettaErrorsTypes.signatureNotVerified]);
     }
 
     if (transaction.auth.spendingCondition && isSingleSig(transaction.auth.spendingCondition)) {

--- a/src/api/routes/rosetta/construction.ts
+++ b/src/api/routes/rosetta/construction.ts
@@ -333,27 +333,24 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
       },
     };
 
-    let feeValue: string;
     // Getting fee info if not operation fee was given in /preprocess
-    if (!options?.fee) {
-      const feeInfo = await new StacksCoreRpcClient().getEstimatedTransferFee();
-      if (feeInfo === undefined || feeInfo === '0') {
-        res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidFee]);
-        return;
-      }
-      feeValue = (BigInt(feeInfo) * BigInt(options.size)).toString();
-      const currency: RosettaCurrency = {
-        symbol: RosettaConstants.symbol,
-        decimals: RosettaConstants.decimals,
-      };
-
-      const fee: RosettaAmount = {
-        value: feeValue,
-        currency,
-      };
-
-      response.suggested_fee = [fee];
+    const feeInfo = await new StacksCoreRpcClient().getEstimatedTransferFee();
+    if (feeInfo === undefined || feeInfo === '0') {
+      res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidFee]);
+      return;
     }
+    const feeValue = (BigInt(feeInfo) * BigInt(options.size)).toString();
+    const currency: RosettaCurrency = {
+      symbol: RosettaConstants.symbol,
+      decimals: RosettaConstants.decimals,
+    };
+
+    const fee: RosettaAmount = {
+      value: feeValue,
+      currency,
+    };
+
+    response.suggested_fee = [fee];
 
     res.json(response);
   });

--- a/src/api/routes/rosetta/mempool.ts
+++ b/src/api/routes/rosetta/mempool.ts
@@ -26,7 +26,7 @@ export function createRosettaMempoolRouter(db: DataStore, chainId: ChainID): Rou
   router.postAsync('/', async (req, res) => {
     const valid: ValidSchema = await rosettaValidateRequest(req.originalUrl, req.body, chainId);
     if (!valid.valid) {
-      res.status(400).json(makeRosettaError(valid));
+      res.status(500).json(makeRosettaError(valid));
       return;
     }
 
@@ -44,7 +44,7 @@ export function createRosettaMempoolRouter(db: DataStore, chainId: ChainID): Rou
   router.postAsync('/transaction', async (req, res) => {
     const valid: ValidSchema = await rosettaValidateRequest(req.originalUrl, req.body, chainId);
     if (!valid.valid) {
-      res.status(400).json(makeRosettaError(valid));
+      res.status(500).json(makeRosettaError(valid));
       return;
     }
 
@@ -56,7 +56,7 @@ export function createRosettaMempoolRouter(db: DataStore, chainId: ChainID): Rou
     const mempoolTxQuery = await db.getMempoolTx({ txId: tx_id });
 
     if (!mempoolTxQuery.found) {
-      return res.status(404).json(RosettaErrors[RosettaErrorsTypes.transactionNotFound]);
+      return res.status(500).json(RosettaErrors[RosettaErrorsTypes.transactionNotFound]);
     }
 
     const operations = getOperations(mempoolTxQuery.result);

--- a/src/api/routes/rosetta/network.ts
+++ b/src/api/routes/rosetta/network.ts
@@ -44,19 +44,19 @@ export function createRosettaNetworkRouter(db: DataStore, chainId: ChainID): Rou
   router.postAsync('/status', async (req, res) => {
     const valid: ValidSchema = await rosettaValidateRequest(req.originalUrl, req.body, chainId);
     if (!valid.valid) {
-      res.status(400).json(makeRosettaError(valid));
+      res.status(500).json(makeRosettaError(valid));
       return;
     }
 
     const block = await getRosettaBlockFromDataStore(db, false);
     if (!block.found) {
-      res.status(404).json(RosettaErrors[RosettaErrorsTypes.blockNotFound]);
+      res.status(500).json(RosettaErrors[RosettaErrorsTypes.blockNotFound]);
       return;
     }
 
     const genesis = await getRosettaBlockFromDataStore(db, false, undefined, 1);
     if (!genesis.found) {
-      res.status(400).json(RosettaErrors[RosettaErrorsTypes.blockNotFound]);
+      res.status(500).json(RosettaErrors[RosettaErrorsTypes.blockNotFound]);
       return;
     }
 
@@ -113,7 +113,7 @@ export function createRosettaNetworkRouter(db: DataStore, chainId: ChainID): Rou
   router.postAsync('/options', async (req, res) => {
     const valid: ValidSchema = await rosettaValidateRequest(req.originalUrl, req.body, chainId);
     if (!valid.valid) {
-      res.status(400).json(makeRosettaError(valid));
+      res.status(500).json(makeRosettaError(valid));
       return;
     }
 

--- a/src/datastore/memory-store.ts
+++ b/src/datastore/memory-store.ts
@@ -581,7 +581,6 @@ export class MemoryDataStore extends (EventEmitter as { new (): DataStoreEventEm
   ): Promise<{ results: DbTx[]; total: number }> {
     throw new Error('Method not implemented');
   }
-
   getMinerRewards({
     blockHeight,
     rewardRecipient,

--- a/src/rosetta-helpers.ts
+++ b/src/rosetta-helpers.ts
@@ -143,7 +143,7 @@ export function processEvents(events: DbEvent[], baseTx: BaseTx, operations: Ros
         break;
       case DbEventTypeId.StxLock:
         const stxLockEvent = event as DbStxLockEvent;
-        operations.push(makeStakeLockOperation(stxLockEvent, baseTx, operations.length))
+        operations.push(makeStakeLockOperation(stxLockEvent, baseTx, operations.length));
         break;
       case DbEventTypeId.NonFungibleTokenAsset:
         break;
@@ -157,7 +157,11 @@ export function processEvents(events: DbEvent[], baseTx: BaseTx, operations: Ros
   });
 }
 
-function makeStakeLockOperation(tx: DbStxLockEvent, baseTx: BaseTx, index: number): RosettaOperation {
+function makeStakeLockOperation(
+  tx: DbStxLockEvent,
+  baseTx: BaseTx,
+  index: number
+): RosettaOperation {
   const stake: RosettaOperation = {
     operation_identifier: { index: index },
     type: getEventTypeString(tx.event_type),

--- a/src/rosetta-helpers.ts
+++ b/src/rosetta-helpers.ts
@@ -142,6 +142,8 @@ export function processEvents(events: DbEvent[], baseTx: BaseTx, operations: Ros
         }
         break;
       case DbEventTypeId.StxLock:
+        const stxLockEvent = event as DbStxLockEvent;
+        operations.push(makeStakeLockOperation(stxLockEvent, baseTx, operations.length))
         break;
       case DbEventTypeId.NonFungibleTokenAsset:
         break;
@@ -153,6 +155,19 @@ export function processEvents(events: DbEvent[], baseTx: BaseTx, operations: Ros
         throw new Error(`Unexpected DbEventTypeId: ${txEventType}`);
     }
   });
+}
+
+function makeStakeLockOperation(tx: DbStxLockEvent, baseTx: BaseTx, index: number): RosettaOperation {
+  const stake: RosettaOperation = {
+    operation_identifier: { index: index },
+    type: getEventTypeString(tx.event_type),
+    status: getTxStatus(baseTx.status),
+    account: {
+      address: unwrapOptional(tx.locked_address, () => 'Unexpected nullish locked_address'),
+    },
+  };
+
+  return stake;
 }
 
 export function getMinerOperations(minerRewards: DbMinerReward[], operations: RosettaOperation[]) {

--- a/src/tests-rosetta/api.ts
+++ b/src/tests-rosetta/api.ts
@@ -19,13 +19,11 @@ import {
   SignedTokenTransferOptions,
   standardPrincipalCV,
   TransactionSigner,
-  UnsignedMultiSigTokenTransferOptions,
   UnsignedTokenTransferOptions,
 } from '@stacks/transactions';
-import { StacksTestnet } from '@stacks/network';
 import * as BN from 'bn.js';
-import { getCoreNodeEndpoint, StacksCoreRpcClient } from '../core-rpc/client';
-import { bufferToHexPrefixString, digestSha512_256 } from '../helpers';
+import { StacksCoreRpcClient } from '../core-rpc/client';
+import { bufferToHexPrefixString } from '../helpers';
 import {
   RosettaConstructionCombineRequest,
   RosettaConstructionCombineResponse,
@@ -60,11 +58,7 @@ import {
   RosettaOperationStatuses,
 } from '../api/rosetta-constants';
 import { getStacksTestnetNetwork, testnetKeys } from '../api/routes/debug';
-import {
-  getOptionsFromOperations,
-  getSignature,
-  getStacksMainnetNetwork,
-} from '../rosetta-helpers';
+import { getSignature, getStacksMainnetNetwork } from '../rosetta-helpers';
 import { makeSigHashPreSign, MessageSignature } from '@stacks/transactions';
 
 describe('Rosetta API', () => {
@@ -772,7 +766,6 @@ describe('Rosetta API', () => {
           },
           related_operations: [],
           type: 'token_transfer',
-          status: null,
           account: {
             address: 'STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6',
             metadata: {},
@@ -793,7 +786,6 @@ describe('Rosetta API', () => {
           },
           related_operations: [],
           type: 'token_transfer',
-          status: null,
           account: {
             address: 'STDE7Y8HV3RX8VBM2TZVWJTS7ZA1XB0SSC3NEVH0',
             metadata: {},
@@ -833,7 +825,6 @@ describe('Rosetta API', () => {
       options: {
         sender_address: 'STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6',
         type: 'token_transfer',
-        status: null,
         suggested_fee_multiplier: 1,
         token_transfer_recipient_address: 'STDE7Y8HV3RX8VBM2TZVWJTS7ZA1XB0SSC3NEVH0',
         amount: '500000',
@@ -866,7 +857,6 @@ describe('Rosetta API', () => {
           },
           related_operations: [],
           type: 'invalid operation type',
-          status: null,
           account: {
             address: 'STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6',
             metadata: {},
@@ -887,7 +877,6 @@ describe('Rosetta API', () => {
           },
           related_operations: [],
           type: 'token_transfer',
-          status: null,
           account: {
             address: 'STDE7Y8HV3RX8VBM2TZVWJTS7ZA1XB0SSC3NEVH0',
             metadata: {},
@@ -938,7 +927,6 @@ describe('Rosetta API', () => {
       options: {
         sender_address: testnetKeys[0].stacksAddress,
         type: 'token_transfer',
-        status: null,
         suggested_fee_multiplier: 1,
         token_transfer_recipient_address: testnetKeys[1].stacksAddress,
         amount: '500000',
@@ -960,7 +948,7 @@ describe('Rosetta API', () => {
     expect(result.type).toBe('application/json');
     expect(JSON.parse(result.text)).toHaveProperty('metadata');
     expect(JSON.parse(result.text)).toHaveProperty('suggested_fee');
-    expect(JSON.parse(result.text).suggested_fee.value).toBe('180');
+    expect(JSON.parse(result.text).suggested_fee[0].value).toBe('180');
   });
 
   test('construction/metadata - failure invalid public key', async () => {
@@ -975,7 +963,6 @@ describe('Rosetta API', () => {
       options: {
         sender_address: testnetKeys[0].stacksAddress,
         type: 'token_transfer',
-        status: null,
         token_transfer_recipient_address: testnetKeys[1].stacksAddress,
         amount: '500000',
         symbol: 'STX',
@@ -1006,7 +993,6 @@ describe('Rosetta API', () => {
       options: {
         sender_address: 'STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6',
         type: 'token_transfer',
-        status: null,
         token_transfer_recipient_address: 'STDE7Y8HV3RX8VBM2TZVWJTS7ZA1XB0SSC3NEVH0',
         amount: '500000',
         symbol: 'STX',
@@ -1044,7 +1030,6 @@ describe('Rosetta API', () => {
       options: {
         sender_address: 'STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6',
         type: 'token',
-        status: null,
         token_transfer_recipient_address: 'STDE7Y8HV3RX8VBM2TZVWJTS7ZA1XB0SSC3NEVH0',
         amount: '500000',
         symbol: 'STX',
@@ -1079,7 +1064,6 @@ describe('Rosetta API', () => {
       options: {
         sender_address: 'abc',
         type: 'token_transfer',
-        status: null,
         token_transfer_recipient_address: 'STDE7Y8HV3RX8VBM2TZVWJTS7ZA1XB0SSC3NEVH0',
         amount: '500000',
         symbol: 'STX',
@@ -1115,7 +1099,6 @@ describe('Rosetta API', () => {
       options: {
         sender_address: 'STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6',
         type: 'token_transfer',
-        status: null,
         token_transfer_recipient_address: 'xyz',
         amount: '500000',
         symbol: 'STX',
@@ -1385,8 +1368,27 @@ describe('Rosetta API', () => {
             network_index: 0,
           },
           related_operations: [],
+          type: 'fee',
+          account: {
+            address: sender,
+            metadata: {},
+          },
+          amount: {
+            value: '-' + fee,
+            currency: {
+              symbol: 'STX',
+              decimals: 6,
+            },
+            metadata: {},
+          },
+        },
+        {
+          operation_identifier: {
+            index: 1,
+            network_index: 0,
+          },
+          related_operations: [],
           type: 'token_transfer',
-          status: null,
           account: {
             address: sender,
             metadata: {},
@@ -1402,12 +1404,11 @@ describe('Rosetta API', () => {
         },
         {
           operation_identifier: {
-            index: 1,
+            index: 2,
             network_index: 0,
           },
           related_operations: [],
           type: 'token_transfer',
-          status: null,
           account: {
             address: recipient,
             metadata: {},
@@ -1423,7 +1424,6 @@ describe('Rosetta API', () => {
         },
       ],
       metadata: {
-        fee: fee,
         account_sequence: 0,
       },
       public_keys: [
@@ -1497,8 +1497,27 @@ describe('Rosetta API', () => {
             network_index: 0,
           },
           related_operations: [],
+          type: 'fee',
+          account: {
+            address: sender,
+            metadata: {},
+          },
+          amount: {
+            value: '-' + fee,
+            currency: {
+              symbol: 'STX',
+              decimals: 6,
+            },
+            metadata: {},
+          },
+        },
+        {
+          operation_identifier: {
+            index: 1,
+            network_index: 0,
+          },
+          related_operations: [],
           type: 'token_transfer',
-          status: null,
           account: {
             address: sender,
             metadata: {},
@@ -1514,12 +1533,11 @@ describe('Rosetta API', () => {
         },
         {
           operation_identifier: {
-            index: 1,
+            index: 2,
             network_index: 0,
           },
           related_operations: [],
           type: 'token_transfer',
-          status: null,
           account: {
             address: recipient,
             metadata: {},
@@ -1574,8 +1592,27 @@ describe('Rosetta API', () => {
             network_index: 0,
           },
           related_operations: [],
+          type: 'fee',
+          account: {
+            address: 'STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6',
+            metadata: {},
+          },
+          amount: {
+            value: '-180',
+            currency: {
+              symbol: 'STX',
+              decimals: 6,
+            },
+            metadata: {},
+          },
+        },
+        {
+          operation_identifier: {
+            index: 1,
+            network_index: 0,
+          },
+          related_operations: [],
           type: 'token_transfer',
-          status: null,
           account: {
             address: 'STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6',
             metadata: {},
@@ -1591,12 +1628,11 @@ describe('Rosetta API', () => {
         },
         {
           operation_identifier: {
-            index: 1,
+            index: 2,
             network_index: 0,
           },
           related_operations: [],
           type: 'token_transfer',
-          status: null,
           account: {
             address: 'STDE7Y8HV3RX8VBM2TZVWJTS7ZA1XB0SSC3NEVH0',
             metadata: {},
@@ -1641,8 +1677,27 @@ describe('Rosetta API', () => {
             network_index: 0,
           },
           related_operations: [],
+          type: 'fee',
+          account: {
+            address: 'STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6',
+            metadata: {},
+          },
+          amount: {
+            value: '-180',
+            currency: {
+              symbol: 'STX',
+              decimals: 6,
+            },
+            metadata: {},
+          },
+        },
+        {
+          operation_identifier: {
+            index: 1,
+            network_index: 0,
+          },
+          related_operations: [],
           type: 'token_transfer',
-          status: null,
           account: {
             address: 'STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6',
             metadata: {},
@@ -1658,12 +1713,11 @@ describe('Rosetta API', () => {
         },
         {
           operation_identifier: {
-            index: 1,
+            index: 2,
             network_index: 0,
           },
           related_operations: [],
           type: 'token_transfer',
-          status: null,
           account: {
             address: 'STDE7Y8HV3RX8VBM2TZVWJTS7ZA1XB0SSC3NEVH0',
             metadata: {},
@@ -1678,9 +1732,7 @@ describe('Rosetta API', () => {
           },
         },
       ],
-      metadata: {
-        fee: '180',
-      },
+      metadata: {},
       public_keys: [
         {
           hex_bytes: '025c13b2fc2261956d8a4ad07d481b1a3b2cbf93a24f992249a61c3a1c4de79c51',
@@ -2001,7 +2053,6 @@ describe('Rosetta API', () => {
           },
           related_operations: [],
           type: 'stacking',
-          status: null,
           account: {
             address: 'STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6',
             metadata: {},
@@ -2044,7 +2095,6 @@ describe('Rosetta API', () => {
       options: {
         sender_address: 'STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6',
         type: 'stacking',
-        status: null,
         suggested_fee_multiplier: 1,
         amount: '500000',
         symbol: 'STX',
@@ -2075,7 +2125,6 @@ describe('Rosetta API', () => {
       options: {
         sender_address: 'STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6',
         type: 'stacking',
-        status: null,
         suggested_fee_multiplier: 1,
         amount: '-500000',
         symbol: 'STX',
@@ -2101,7 +2150,7 @@ describe('Rosetta API', () => {
     expect(JSON.parse(result.text).metadata).toHaveProperty('contract_address');
     expect(JSON.parse(result.text).metadata).toHaveProperty('contract_name');
     expect(JSON.parse(result.text).metadata).toHaveProperty('burn_block_height');
-    expect(JSON.parse(result.text).suggested_fee.value).toBe('260');
+    expect(JSON.parse(result.text).suggested_fee[0].value).toBe('260');
   });
 
   /* rosetta construction end */

--- a/src/tests-rosetta/api.ts
+++ b/src/tests-rosetta/api.ts
@@ -116,7 +116,7 @@ describe('Rosetta API', () => {
 
   test('network/options - bad request', async () => {
     const query1 = await supertest(api.server).post(`/rosetta/v1/network/options`).send({});
-    expect(query1.status).toBe(400);
+    expect(query1.status).toBe(500);
     expect(query1.type).toBe('application/json');
     expect(JSON.parse(query1.text)).toEqual({
       code: 613,
@@ -130,7 +130,7 @@ describe('Rosetta API', () => {
     const query1 = await supertest(api.server)
       .post(`/rosetta/v1/network/status`)
       .send({ network_identifier: { blockchain: 'bitcoin', network: 'testnet' } });
-    expect(query1.status).toBe(400);
+    expect(query1.status).toBe(500);
     expect(query1.type).toBe('application/json');
     expect(JSON.parse(query1.text)).toEqual({
       code: 611,
@@ -143,7 +143,7 @@ describe('Rosetta API', () => {
     const query1 = await supertest(api.server)
       .post(`/rosetta/v1/network/status`)
       .send({ network_identifier: { blockchain: 'stacks', network: 'mainnet' } });
-    expect(query1.status).toBe(400);
+    expect(query1.status).toBe(500);
     expect(query1.type).toBe('application/json');
     expect(JSON.parse(query1.text)).toEqual({
       code: 610,
@@ -394,7 +394,7 @@ describe('Rosetta API', () => {
         block_identifier: { index: 3, hash: '0x3a' },
         transaction_identifier: { hash: '3' },
       });
-    expect(query1.status).toBe(400);
+    expect(query1.status).toBe(500);
     expect(query1.type).toBe('application/json');
     expect(JSON.parse(query1.text)).toEqual({
       code: 608,
@@ -622,7 +622,7 @@ describe('Rosetta API', () => {
     };
 
     const result = await supertest(api.server).post(`/rosetta/v1/account/balance/`).send(request);
-    expect(result.status).toBe(400);
+    expect(result.status).toBe(500);
     expect(result.type).toBe('application/json');
 
     const expectResponse = {
@@ -648,7 +648,7 @@ describe('Rosetta API', () => {
     };
 
     const result = await supertest(api.server).post(`/rosetta/v1/account/balance/`).send(request);
-    expect(result.status).toBe(400);
+    expect(result.status).toBe(500);
     expect(result.type).toBe('application/json');
 
     const expectResponse = {
@@ -675,7 +675,7 @@ describe('Rosetta API', () => {
       },
     };
     const result = await supertest(api.server).post(`/rosetta/v1/account/balance/`).send(request);
-    expect(result.status).toBe(400);
+    expect(result.status).toBe(500);
     expect(result.type).toBe('application/json');
 
     const expectResponse = {
@@ -731,7 +731,7 @@ describe('Rosetta API', () => {
     const result2 = await supertest(api.server)
       .post(`/rosetta/v1/construction/derive`)
       .send(request2);
-    expect(result2.status).toBe(400);
+    expect(result2.status).toBe(500);
 
     const expectedResponse2 = RosettaErrors[RosettaErrorsTypes.invalidCurveType];
 
@@ -751,7 +751,7 @@ describe('Rosetta API', () => {
     const result3 = await supertest(api.server)
       .post(`/rosetta/v1/construction/derive`)
       .send(request3);
-    expect(result3.status).toBe(400);
+    expect(result3.status).toBe(500);
 
     const expectedResponse3 = RosettaErrors[RosettaErrorsTypes.invalidPublicKey];
 
@@ -919,7 +919,7 @@ describe('Rosetta API', () => {
     const result2 = await supertest(api.server)
       .post(`/rosetta/v1/construction/preprocess`)
       .send(request2);
-    expect(result2.status).toBe(400);
+    expect(result2.status).toBe(500);
 
     const expectedResponse2 = RosettaErrors[RosettaErrorsTypes.invalidOperation];
 
@@ -995,7 +995,7 @@ describe('Rosetta API', () => {
       .post(`/rosetta/v1/construction/metadata`)
       .send(request);
 
-    expect(result.status).toBe(400);
+    expect(result.status).toBe(500);
     expect(result.type).toBe('application/json');
 
     expect(JSON.parse(result.text)).toEqual(RosettaErrors[RosettaErrorsTypes.invalidPublicKey]);
@@ -1020,7 +1020,7 @@ describe('Rosetta API', () => {
       .post(`/rosetta/v1/construction/metadata`)
       .send(request);
 
-    expect(result.status).toBe(400);
+    expect(result.status).toBe(500);
     expect(result.type).toBe('application/json');
 
     const expectResponse = {
@@ -1058,7 +1058,7 @@ describe('Rosetta API', () => {
       .post(`/rosetta/v1/construction/metadata`)
       .send(request);
 
-    expect(result.status).toBe(400);
+    expect(result.status).toBe(500);
     expect(result.type).toBe('application/json');
 
     const expectResponse = {
@@ -1094,7 +1094,7 @@ describe('Rosetta API', () => {
       .post(`/rosetta/v1/construction/metadata`)
       .send(request);
 
-    expect(result.status).toBe(400);
+    expect(result.status).toBe(500);
     expect(result.type).toBe('application/json');
 
     const expectResponse = {
@@ -1129,7 +1129,7 @@ describe('Rosetta API', () => {
       .post(`/rosetta/v1/construction/metadata`)
       .send(request);
 
-    expect(result.status).toBe(400);
+    expect(result.status).toBe(500);
     expect(result.type).toBe('application/json');
 
     const expectResponse = {
@@ -1196,7 +1196,7 @@ describe('Rosetta API', () => {
     };
 
     const result = await supertest(api.server).post(`/rosetta/v1/construction/hash`).send(request);
-    expect(result.status).toBe(400);
+    expect(result.status).toBe(500);
 
     const expectedResponse = RosettaErrors[RosettaErrorsTypes.invalidTransactionString];
 
@@ -1215,7 +1215,7 @@ describe('Rosetta API', () => {
     };
 
     const result = await supertest(api.server).post(`/rosetta/v1/construction/hash`).send(request);
-    expect(result.status).toBe(400);
+    expect(result.status).toBe(500);
 
     const expectedResponse = RosettaErrors[RosettaErrorsTypes.transactionNotSigned];
 
@@ -1359,7 +1359,7 @@ describe('Rosetta API', () => {
     const result = await supertest(api.server)
       .post(`/rosetta/v1/construction/submit`)
       .send(request);
-    expect(result.status).toBe(400);
+    expect(result.status).toBe(500);
     const expectedResponse = RosettaErrors[RosettaErrorsTypes.invalidTransactionString];
 
     console.log(expectedResponse);
@@ -1553,7 +1553,7 @@ describe('Rosetta API', () => {
       .post(`/rosetta/v1/construction/payloads`)
       .send(request);
 
-    expect(result.status).toBe(400);
+    expect(result.status).toBe(500);
     expect(result.type).toBe('application/json');
 
     const expectedResponse = RosettaErrors[RosettaErrorsTypes.needOnePublicKey];
@@ -1620,7 +1620,7 @@ describe('Rosetta API', () => {
       .post(`/rosetta/v1/construction/payloads`)
       .send(request);
 
-    expect(result.status).toBe(400);
+    expect(result.status).toBe(500);
     expect(result.type).toBe('application/json');
 
     const expectedResponse = RosettaErrors[RosettaErrorsTypes.emptyPublicKey];
@@ -1693,7 +1693,7 @@ describe('Rosetta API', () => {
       .post(`/rosetta/v1/construction/payloads`)
       .send(request);
 
-    expect(result.status).toBe(400);
+    expect(result.status).toBe(500);
     expect(result.type).toBe('application/json');
 
     const expectedResponse = RosettaErrors[RosettaErrorsTypes.invalidCurveType];
@@ -1812,7 +1812,7 @@ describe('Rosetta API', () => {
       .post(`/rosetta/v1/construction/combine`)
       .send(request);
 
-    expect(result.status).toBe(400);
+    expect(result.status).toBe(500);
     expect(result.type).toBe('application/json');
 
     const expectedResponse = RosettaErrors[RosettaErrorsTypes.needOnlyOneSignature];
@@ -1849,7 +1849,7 @@ describe('Rosetta API', () => {
       .post(`/rosetta/v1/construction/combine`)
       .send(request);
 
-    expect(result.status).toBe(400);
+    expect(result.status).toBe(500);
     expect(result.type).toBe('application/json');
 
     const expectedResponse = RosettaErrors[RosettaErrorsTypes.invalidTransactionString];
@@ -1885,7 +1885,7 @@ describe('Rosetta API', () => {
       .post(`/rosetta/v1/construction/combine`)
       .send(request);
 
-    expect(result.status).toBe(400);
+    expect(result.status).toBe(500);
     expect(result.type).toBe('application/json');
 
     const expectedResponse = RosettaErrors[RosettaErrorsTypes.invalidSignature];
@@ -1941,7 +1941,7 @@ describe('Rosetta API', () => {
       .post(`/rosetta/v1/construction/combine`)
       .send(request);
 
-    expect(result.status).toBe(400);
+    expect(result.status).toBe(500);
     expect(result.type).toBe('application/json');
 
     const expectedResponse = RosettaErrors[RosettaErrorsTypes.signatureNotVerified];
@@ -1979,7 +1979,7 @@ describe('Rosetta API', () => {
       .post(`/rosetta/v1/construction/combine`)
       .send(request);
 
-    expect(result.status).toBe(400);
+    expect(result.status).toBe(500);
     expect(result.type).toBe('application/json');
 
     const expectedResponse = RosettaErrors[RosettaErrorsTypes.signatureNotVerified];

--- a/src/tests-rosetta/offline-api-tests.ts
+++ b/src/tests-rosetta/offline-api-tests.ts
@@ -147,7 +147,7 @@ describe('Rosetta API', () => {
     const result2 = await supertest(api.server)
       .post(`/rosetta/v1/construction/derive`)
       .send(request2);
-    expect(result2.status).toBe(400);
+    expect(result2.status).toBe(500);
 
     const expectedResponse2 = RosettaErrors[RosettaErrorsTypes.invalidCurveType];
 
@@ -167,7 +167,7 @@ describe('Rosetta API', () => {
     const result3 = await supertest(api.server)
       .post(`/rosetta/v1/construction/derive`)
       .send(request3);
-    expect(result3.status).toBe(400);
+    expect(result3.status).toBe(500);
 
     const expectedResponse3 = RosettaErrors[RosettaErrorsTypes.invalidPublicKey];
 
@@ -188,7 +188,6 @@ describe('Rosetta API', () => {
           },
           related_operations: [],
           type: 'token_transfer',
-          status: null,
           account: {
             address: 'STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6',
             metadata: {},
@@ -209,7 +208,6 @@ describe('Rosetta API', () => {
           },
           related_operations: [],
           type: 'token_transfer',
-          status: null,
           account: {
             address: 'STDE7Y8HV3RX8VBM2TZVWJTS7ZA1XB0SSC3NEVH0',
             metadata: {},
@@ -249,7 +247,6 @@ describe('Rosetta API', () => {
       options: {
         sender_address: 'STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6',
         type: 'token_transfer',
-        status: null,
         suggested_fee_multiplier: 1,
         token_transfer_recipient_address: 'STDE7Y8HV3RX8VBM2TZVWJTS7ZA1XB0SSC3NEVH0',
         amount: '500000',
@@ -392,8 +389,27 @@ describe('Rosetta API', () => {
             network_index: 0,
           },
           related_operations: [],
+          type: 'fee',
+          account: {
+            address: sender,
+            metadata: {},
+          },
+          amount: {
+            value: '-' + fee,
+            currency: {
+              symbol: 'STX',
+              decimals: 6,
+            },
+            metadata: {},
+          },
+        },
+        {
+          operation_identifier: {
+            index: 1,
+            network_index: 0,
+          },
+          related_operations: [],
           type: 'token_transfer',
-          status: null,
           account: {
             address: sender,
             metadata: {},
@@ -409,12 +425,11 @@ describe('Rosetta API', () => {
         },
         {
           operation_identifier: {
-            index: 1,
+            index: 2,
             network_index: 0,
           },
           related_operations: [],
           type: 'token_transfer',
-          status: null,
           account: {
             address: recipient,
             metadata: {},
@@ -503,8 +518,27 @@ describe('Rosetta API', () => {
             network_index: 0,
           },
           related_operations: [],
+          type: 'fee',
+          account: {
+            address: sender,
+            metadata: {},
+          },
+          amount: {
+            value: '-' + fee,
+            currency: {
+              symbol: 'STX',
+              decimals: 6,
+            },
+            metadata: {},
+          },
+        },
+        {
+          operation_identifier: {
+            index: 1,
+            network_index: 0,
+          },
+          related_operations: [],
           type: 'token_transfer',
-          status: null,
           account: {
             address: sender,
             metadata: {},
@@ -520,12 +554,11 @@ describe('Rosetta API', () => {
         },
         {
           operation_identifier: {
-            index: 1,
+            index: 2,
             network_index: 0,
           },
           related_operations: [],
           type: 'token_transfer',
-          status: null,
           account: {
             address: recipient,
             metadata: {},
@@ -559,7 +592,7 @@ describe('Rosetta API', () => {
       .post(`/rosetta/v1/construction/payloads`)
       .send(request);
 
-    expect(result.status).toBe(400);
+    expect(result.status).toBe(500);
     expect(result.type).toBe('application/json');
 
     const expectedResponse = RosettaErrors[RosettaErrorsTypes.needOnePublicKey];
@@ -671,7 +704,7 @@ describe('Rosetta API', () => {
       .post(`/rosetta/v1/construction/combine`)
       .send(request);
 
-    expect(result.status).toBe(400);
+    expect(result.status).toBe(500);
     expect(result.type).toBe('application/json');
 
     const expectedResponse = RosettaErrors[RosettaErrorsTypes.needOnlyOneSignature];


### PR DESCRIPTION
On this PR:
- Vesting info can be queried from `account/balance` using sub-accounts.
- Add `stx-lock` (tokens locking for staking) event parser. 