### PR TITLE
fix: dont require public key in metadata call

### DIFF
--- a/src/api/rosetta-constants.ts
+++ b/src/api/rosetta-constants.ts
@@ -114,6 +114,7 @@ export enum RosettaErrorsTypes {
   missingTransactionSize,
   stackingEligibityError,
   invalidSubAccount,
+  missingSenderAddress,
 }
 
 // All possible errors
@@ -328,6 +329,11 @@ export const RosettaErrors: Record<RosettaErrorsTypes, RosettaError> = {
   [RosettaErrorsTypes.invalidSubAccount]: {
     code: 641,
     message: 'Invalid sub-account',
+    retriable: false,
+  },
+  [RosettaErrorsTypes.missingSenderAddress]: {
+    code: 642,
+    message: 'Missing sender address',
     retriable: false,
   },
 };

--- a/src/api/routes/rosetta/construction.ts
+++ b/src/api/routes/rosetta/construction.ts
@@ -61,6 +61,7 @@ import {
   getStacksNetwork,
   makePresignHash,
   verifySignature,
+  stxAddressToBitcoinAddress,
 } from './../../../rosetta-helpers';
 import { makeRosettaError, rosettaValidateRequest, ValidSchema } from './../../rosetta-validate';
 
@@ -283,37 +284,11 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
         return;
     }
 
-    if (!request.public_keys || request.public_keys.length != 1) {
-      res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidPublicKey]);
+    if (typeof options.sender_address === 'undefined') {
+      res.status(500).json(RosettaErrors[RosettaErrorsTypes.missingSenderAddress]);
       return;
     }
-
-    const publicKey: RosettaPublicKey = request.public_keys[0];
-
-    if (has0xPrefix(publicKey.hex_bytes)) {
-      publicKey.hex_bytes = publicKey.hex_bytes.replace('0x', '');
-    }
-
-    let stxAddress;
-    try {
-      const btcAddress = publicKeyToBitcoinAddress(
-        publicKey.hex_bytes,
-        request.network_identifier.network
-      );
-      if (btcAddress === undefined) {
-        res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidPublicKey]);
-        return;
-      }
-      stxAddress = bitcoinAddressToSTXAddress(btcAddress);
-
-      if (stxAddress !== options.sender_address) {
-        res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidPublicKey]);
-        return;
-      }
-    } catch (e) {
-      res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidPublicKey]);
-      return;
-    }
+    const stxAddress = options.sender_address;
 
     // Getting nonce info
     const accountInfo = await new StacksCoreRpcClient().getAccount(stxAddress);

--- a/src/tests-rosetta/api.ts
+++ b/src/tests-rosetta/api.ts
@@ -286,8 +286,8 @@ describe('Rosetta API', () => {
         network_identifier: { blockchain: 'stacks', network: 'testnet' },
         block_identifier: {},
       });
-    console.log(query1);
-    expect(query1.status).toBe(200);
+
+      expect(query1.status).toBe(200);
     expect(query1.type).toBe('application/json');
     expect(JSON.parse(query1.text)).toEqual({
       block: {

--- a/src/tests-rosetta/api.ts
+++ b/src/tests-rosetta/api.ts
@@ -286,6 +286,7 @@ describe('Rosetta API', () => {
         network_identifier: { blockchain: 'stacks', network: 'testnet' },
         block_identifier: {},
       });
+    console.log(query1);
     expect(query1.status).toBe(200);
     expect(query1.type).toBe('application/json');
     expect(JSON.parse(query1.text)).toEqual({
@@ -916,9 +917,6 @@ describe('Rosetta API', () => {
   });
 
   test('construction/metadata - success', async () => {
-    const publicKey = publicKeyToString(
-      getPublicKey(createStacksPrivateKey(testnetKeys[0].secretKey))
-    );
     const request: RosettaConstructionMetadataRequest = {
       network_identifier: {
         blockchain: 'stacks',
@@ -935,7 +933,6 @@ describe('Rosetta API', () => {
         max_fee: '12380898',
         size: 180,
       },
-      public_keys: [{ hex_bytes: publicKey, curve_type: 'secp256k1' }],
     };
 
     const result = await supertest(api.server)
@@ -949,43 +946,6 @@ describe('Rosetta API', () => {
     expect(JSON.parse(result.text)).toHaveProperty('metadata');
     expect(JSON.parse(result.text)).toHaveProperty('suggested_fee');
     expect(JSON.parse(result.text).suggested_fee[0].value).toBe('180');
-  });
-
-  test('construction/metadata - failure invalid public key', async () => {
-    const publicKey = publicKeyToString(
-      getPublicKey(createStacksPrivateKey(testnetKeys[2].secretKey))
-    );
-    const request: RosettaConstructionMetadataRequest = {
-      network_identifier: {
-        blockchain: 'stacks',
-        network: 'testnet',
-      },
-      options: {
-        sender_address: testnetKeys[0].stacksAddress,
-        type: 'token_transfer',
-        token_transfer_recipient_address: testnetKeys[1].stacksAddress,
-        amount: '500000',
-        symbol: 'STX',
-        decimals: 6,
-        max_fee: '12380898',
-        size: 180,
-      },
-      public_keys: [
-        {
-          hex_bytes: publicKey,
-          curve_type: 'secp256k1',
-        },
-      ],
-    };
-
-    const result = await supertest(api.server)
-      .post(`/rosetta/v1/construction/metadata`)
-      .send(request);
-
-    expect(result.status).toBe(500);
-    expect(result.type).toBe('application/json');
-
-    expect(JSON.parse(result.text)).toEqual(RosettaErrors[RosettaErrorsTypes.invalidPublicKey]);
   });
 
   test('construction/metadata - empty network identifier', async () => {

--- a/src/tests-rosetta/api.ts
+++ b/src/tests-rosetta/api.ts
@@ -287,7 +287,7 @@ describe('Rosetta API', () => {
         block_identifier: {},
       });
 
-      expect(query1.status).toBe(200);
+    expect(query1.status).toBe(200);
     expect(query1.type).toBe('application/json');
     expect(JSON.parse(query1.text)).toEqual({
       block: {


### PR DESCRIPTION
Don't require public key in meatadata as they are not needed.